### PR TITLE
Tackling-bullet-points/Bullet-point-1

### DIFF
--- a/solana/modules/matching-engine-testing/tests/README.md
+++ b/solana/modules/matching-engine-testing/tests/README.md
@@ -10,9 +10,35 @@ Each test is a function that is annotated with `#[tokio::test]`.
 
 Each test is a test for a specific scenario, and uses the `TestingEngine` to execute a series of instruction triggers.
 
-The `TestingEngine` is initialized with a `TestingContext`. The `TestingContext` holds the solana program test context, the actors, the transfer direction, created vaas, as well as some constants.
+The `TestingEngine` is initialized with a `TestingContext`. The `TestingContext` holds the the `TestingActors`, the transfer direction, created vaas, as well as some constants.
+
+The `TestingActors` are structs that hold information for any keypair that is setup before the tests are conducted. These include the `owner` the `owner_assistant` and the `Solvers`.
 
 The `TestingEngine` is used to execute the instruction triggers in the order they are provided. See the `testing_engine/engine.rs` file for more details.
+
+## How to run the tests
+
+### Setup for running the tests
+
+The program must be built. This is done by entering the `solana/programs/matching-enginge` directory and running `cargo build-sbf --features mainnet`. With an incorrect `so` file, the tests will not be run against the correct program.
+
+```bash
+cd solana/programs/matching-engine
+cargo build-sbf --features mainnet
+```
+
+### Running the tests
+
+The tests are run by the following command
+
+```bash
+cd solana/modules/matching-engine-testing
+cargo test-sbf --features mainnet -- --show-output --test-threads 5
+```
+
+#### ❗❗ NOTE when running tests
+In order to run tests successfully and avoiding an annoying error due to an RpcTimeout, use a low number of `--test-threads`. This will depend on the local machine. The current recommended threads is `5`.
+
 
 ## Happy path integration tests
 

--- a/solana/modules/matching-engine-testing/tests/shimful/fast_market_order_shim.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/fast_market_order_shim.rs
@@ -33,16 +33,14 @@ use wormhole_io::TypePrefixedPayload;
 /// # Arguments
 ///
 /// * `testing_context` - The testing context
-/// * `payer_signer` - The payer signer keypair
-/// * `fast_market_order` - The fast market order state
-/// * `guardian_set_pubkey` - The guardian set pubkey
-/// * `guardian_signatures_pubkey` - The guardian signatures pubkey
-/// * `guardian_set_bump` - The guardian set bump
+/// * `test_context` - The program test context
 /// * `expected_error` - The expected error
+/// * `current_state` - The current testing engine state
+/// * `config` - The initialization configuration
 ///
-/// # Asserts
+/// # Returns
 ///
-/// * The expected error, if any, is reached when executing the instruction
+/// * `TestingEngineState` - The updated testing engine state
 pub async fn initialize_fast_market_order_shimful(
     testing_context: &TestingContext,
     test_context: &mut ProgramTestContext,
@@ -134,9 +132,7 @@ pub async fn initialize_fast_market_order_shimful(
 /// * `payer_signer` - The payer signer keypair
 /// * `program_id` - The program id
 /// * `fast_market_order` - The fast market order state
-/// * `guardian_set_pubkey` - The guardian set pubkey
-/// * `guardian_signatures_pubkey` - The guardian signatures pubkey
-/// * `guardian_set_bump` - The guardian set bump
+/// * `guardian_signature_info` - Information about guardian signatures
 ///
 /// # Returns
 ///
@@ -184,7 +180,8 @@ pub fn initialize_fast_market_order_shimful_instruction(
 /// # Arguments
 ///
 /// * `testing_context` - The testing context
-/// * `refund_recipient_keypair` - The refund recipient keypair that will receive the refund after closing the fast market order account
+/// * `test_context` - The program test context
+/// * `refund_recipient_keypair` - The refund recipient keypair that will receive the refund
 /// * `fast_market_order_address` - The fast market order account address
 /// * `expected_error` - The expected error
 ///

--- a/solana/modules/matching-engine-testing/tests/shimful/fast_market_order_shim.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/fast_market_order_shim.rs
@@ -92,8 +92,8 @@ pub async fn initialize_fast_market_order_shimful(
             &[initialize_fast_market_order_ix],
             Some(&payer_signer.pubkey()),
             &[&payer_signer],
-            1000000000,
-            1000000000,
+            None,
+            None,
         )
         .await;
     testing_context

--- a/solana/modules/matching-engine-testing/tests/shimful/post_message.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/post_message.rs
@@ -110,6 +110,21 @@ pub async fn set_up_post_message_transaction_test(
     );
 }
 
+/// Set up post message transaction
+///
+/// This function sets up a post message transaction
+///
+/// # Arguments
+///
+/// * `payload` - The payload to post
+/// * `payer_signer` - The payer signer
+/// * `emitter_signer` - The emitter signer
+/// * `recent_blockhash` - The recent blockhash
+///
+/// # Returns
+///
+/// * `VersionedTransaction` - The versioned transaction that can be executed to post the message
+/// * `BumpCosts` - The bump costs for the message and sequence
 fn set_up_post_message_transaction(
     payload: &[u8],
     payer_signer: &Keypair,

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_execute_order.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_execute_order.rs
@@ -1,8 +1,6 @@
-use crate::testing_engine::config::{
-    ExecuteOrderInstructionConfig, ExpectedError, InstructionConfig,
-};
+use crate::testing_engine::config::{ExecuteOrderInstructionConfig, InstructionConfig};
 use crate::testing_engine::setup::{TestingContext, TransferDirection};
-use crate::testing_engine::state::TestingEngineState;
+use crate::testing_engine::state::{OrderExecutedState, TestingEngineState};
 
 use super::super::utils;
 use anchor_spl::token::spl_token;
@@ -11,7 +9,7 @@ use common::wormhole_cctp_solana::cctp::{
 };
 use matching_engine::fallback::execute_order::{ExecuteOrderCctpShim, ExecuteOrderShimAccounts};
 use solana_program_test::ProgramTestContext;
-use solana_sdk::{pubkey::Pubkey, signer::Signer, sysvar::SysvarId, transaction::Transaction};
+use solana_sdk::{pubkey::Pubkey, signer::Signer, sysvar::SysvarId};
 use utils::constants::*;
 use wormhole_svm_definitions::solana::CORE_BRIDGE_PROGRAM_ID;
 use wormhole_svm_definitions::{
@@ -22,7 +20,93 @@ use wormhole_svm_definitions::{
     EVENT_AUTHORITY_SEED,
 };
 
-pub struct ExecuteOrderFallbackAccounts {
+/// Execute an order using the shim
+///
+/// # Arguments
+///
+/// * `testing_context` - The testing context of the testing engine
+/// * `test_context` - Mutable reference to the test context
+/// * `current_state` - The current state of the testing engine
+/// * `config` - The execute order instruction config
+///
+/// # Returns
+///
+/// The new state of the testing engine
+pub async fn execute_order_shimful(
+    testing_context: &TestingContext,
+    test_context: &mut ProgramTestContext,
+    current_state: &TestingEngineState,
+    config: &ExecuteOrderInstructionConfig,
+) -> TestingEngineState {
+    let expected_error = config.expected_error();
+    let fixture_accounts = testing_context
+        .get_fixture_accounts()
+        .expect("Pre-made fixture accounts not found");
+
+    let execute_order_fallback_accounts = ExecuteOrderShimfulAccounts::new(
+        testing_context,
+        current_state,
+        config,
+        &fixture_accounts,
+        config.fast_market_order_address,
+    );
+    let program_id = &testing_context.get_matching_engine_program_id();
+    let payer_signer = config
+        .payer_signer
+        .clone()
+        .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
+
+    let clock_id = solana_program::clock::Clock::id();
+    let execute_order_ix_accounts =
+        create_execute_order_shim_accounts(&execute_order_fallback_accounts, &clock_id);
+
+    let execute_order_ix = ExecuteOrderCctpShim {
+        program_id,
+        accounts: execute_order_ix_accounts,
+    }
+    .instruction();
+
+    let slots_to_fast_forward = config.fast_forward_slots;
+    if slots_to_fast_forward > 0 {
+        crate::testing_engine::engine::fast_forward_slots(test_context, slots_to_fast_forward)
+            .await;
+    }
+    let transaction = testing_context
+        .create_transaction(
+            test_context,
+            &[execute_order_ix],
+            Some(&payer_signer.pubkey()),
+            &[&payer_signer],
+            None,
+            None,
+        )
+        .await;
+    testing_context
+        .execute_and_verify_transaction(test_context, transaction, expected_error)
+        .await;
+    if config.expected_error.is_none() {
+        let auction_accounts = current_state
+            .auction_accounts()
+            .expect("Auction accounts not found");
+        let order_executed_state =
+            create_order_executed_state(config, &execute_order_fallback_accounts);
+        TestingEngineState::OrderExecuted {
+            base: current_state.base().clone(),
+            initialized: current_state.initialized().unwrap().clone(),
+            router_endpoints: current_state.router_endpoints().unwrap().clone(),
+            fast_market_order: current_state.fast_market_order().cloned(),
+            auction_state: current_state.auction_state().clone(),
+            order_executed: order_executed_state,
+            auction_accounts: auction_accounts.clone(),
+            order_prepared: current_state.order_prepared().cloned(),
+        }
+    } else {
+        current_state.clone()
+    }
+}
+
+/// A helper struct for the accounts for the execute order shimful instruction that disregards the lifetime
+struct ExecuteOrderShimfulAccounts {
     pub signer: Pubkey,
     pub custodian: Pubkey,
     pub fast_market_order_address: Pubkey,
@@ -35,18 +119,35 @@ pub struct ExecuteOrderFallbackAccounts {
     pub to_router_endpoint: Pubkey,
     pub remote_token_messenger: Pubkey,
     pub token_messenger: Pubkey,
+    pub local_token: Pubkey,
+    pub token_messenger_minter_sender_authority: Pubkey,
+    pub token_messenger_minter_event_authority: Pubkey,
+    pub messenger_transmitter_config: Pubkey,
+    pub token_minter: Pubkey,
+    pub executor_token: Pubkey,
+    pub cctp_message: Pubkey,
+    pub post_message_sequence: Pubkey,
+    pub post_message_message: Pubkey,
 }
 
-impl ExecuteOrderFallbackAccounts {
+impl ExecuteOrderShimfulAccounts {
     pub fn new(
+        testing_context: &TestingContext,
         current_state: &TestingEngineState,
-        payer_signer: &Pubkey,
+        config: &ExecuteOrderInstructionConfig,
         fixture_accounts: &utils::account_fixtures::FixtureAccounts,
         override_fast_market_order_address: Option<Pubkey>,
     ) -> Self {
+        let payer_signer = config
+            .payer_signer
+            .clone()
+            .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
         let transfer_direction = current_state.base().transfer_direction;
         let auction_accounts = current_state.auction_accounts().unwrap();
         let active_auction_state = current_state.auction_state().get_active_auction().unwrap();
+        let initial_participant = active_auction_state.initial_offer.participant;
+        let active_auction = active_auction_state.auction_address;
+        let custodian = auction_accounts.custodian;
         let fast_market_order_address = override_fast_market_order_address.unwrap_or_else(|| {
             current_state
                 .fast_market_order()
@@ -62,9 +163,53 @@ impl ExecuteOrderFallbackAccounts {
             }
             _ => panic!("Unsupported transfer direction"),
         };
+        let program_id = &testing_context.get_matching_engine_program_id();
+        let cctp_message = Pubkey::find_program_address(
+            &[common::CCTP_MESSAGE_SEED_PREFIX, &active_auction.to_bytes()],
+            program_id,
+        )
+        .0;
+        let token_messenger_minter_sender_authority = Pubkey::find_program_address(
+            &[b"sender_authority"],
+            &TOKEN_MESSENGER_MINTER_PROGRAM_ID,
+        )
+        .0;
+        let messenger_transmitter_config = Pubkey::find_program_address(
+            &[b"message_transmitter"],
+            &MESSAGE_TRANSMITTER_PROGRAM_ID,
+        )
+        .0;
+        let token_messenger =
+            Pubkey::find_program_address(&[b"token_messenger"], &TOKEN_MESSENGER_MINTER_PROGRAM_ID)
+                .0;
+        assert_eq!(token_messenger, fixture_accounts.token_messenger);
+        let token_minter =
+            Pubkey::find_program_address(&[b"token_minter"], &TOKEN_MESSENGER_MINTER_PROGRAM_ID).0;
+        let local_token = Pubkey::find_program_address(
+            &[b"local_token", &USDC_MINT.to_bytes()],
+            &TOKEN_MESSENGER_MINTER_PROGRAM_ID,
+        )
+        .0;
+        let token_messenger_minter_event_authority = Pubkey::find_program_address(
+            &[EVENT_AUTHORITY_SEED],
+            &TOKEN_MESSENGER_MINTER_PROGRAM_ID,
+        )
+        .0;
+        let post_message_sequence = wormhole_svm_definitions::find_emitter_sequence_address(
+            &custodian,
+            &CORE_BRIDGE_PROGRAM_ID,
+        )
+        .0;
+        let post_message_message = wormhole_svm_definitions::find_shim_message_address(
+            &custodian,
+            &POST_MESSAGE_SHIM_PROGRAM_ID,
+        )
+        .0;
+        let solver = config.actor_enum.get_actor(&testing_context.testing_actors);
+        let executor_token = solver.token_account_address(&config.token_enum).unwrap();
 
         Self {
-            signer: *payer_signer,
+            signer: payer_signer.pubkey(),
             custodian: auction_accounts.custodian,
             fast_market_order_address,
             active_auction: active_auction_state.auction_address,
@@ -72,146 +217,32 @@ impl ExecuteOrderFallbackAccounts {
             active_auction_config: auction_accounts.auction_config,
             active_auction_best_offer_token: auction_accounts.offer_token,
             initial_offer_token: auction_accounts.offer_token,
-            initial_participant: *payer_signer,
+            initial_participant,
             to_router_endpoint: auction_accounts.to_router_endpoint,
             remote_token_messenger,
-            token_messenger: fixture_accounts.token_messenger,
+            token_messenger,
+            local_token,
+            token_messenger_minter_sender_authority,
+            token_messenger_minter_event_authority,
+            messenger_transmitter_config,
+            token_minter,
+            executor_token,
+            cctp_message,
+            post_message_sequence,
+            post_message_message,
         }
     }
 }
 
-pub struct ExecuteOrderFallbackFixture {
-    pub cctp_message: Pubkey,
-    pub post_message_sequence: Pubkey,
-    pub post_message_message: Pubkey,
-    pub accounts: ExecuteOrderFallbackFixtureAccounts,
-}
-
-pub struct ExecuteOrderFallbackFixtureAccounts {
-    pub local_token: Pubkey,
-    pub token_messenger: Pubkey,
-    pub remote_token_messenger: Pubkey,
-    pub token_messenger_minter_sender_authority: Pubkey,
-    pub token_messenger_minter_event_authority: Pubkey,
-    pub messenger_transmitter_config: Pubkey,
-    pub token_minter: Pubkey,
-    pub executor_token: Pubkey,
-}
-
-pub async fn execute_order_shimful(
-    testing_context: &TestingContext,
-    test_context: &mut ProgramTestContext,
+fn create_order_executed_state(
     config: &ExecuteOrderInstructionConfig,
-    execute_order_fallback_accounts: &ExecuteOrderFallbackAccounts,
-    expected_error: Option<&ExpectedError>,
-) -> Option<ExecuteOrderFallbackFixture> {
-    let program_id = &testing_context.get_matching_engine_program_id();
-    let payer_signer = config
-        .payer_signer
-        .clone()
-        .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
-
-    let execute_order_fallback_fixture = create_execute_order_fallback_fixture(
-        testing_context,
-        config,
-        execute_order_fallback_accounts,
-    );
-    let clock_id = solana_program::clock::Clock::id();
-    let execute_order_ix_accounts = create_execute_order_shim_accounts(
-        execute_order_fallback_accounts,
-        &execute_order_fallback_fixture,
-        &clock_id,
-    );
-
-    let execute_order_ix = ExecuteOrderCctpShim {
-        program_id,
-        accounts: execute_order_ix_accounts,
-    }
-    .instruction();
-
-    // Considering fast forwarding blocks here for deadline to be reached
-    let recent_blockhash = testing_context
-        .get_new_latest_blockhash(test_context)
-        .await
-        .unwrap();
-    let slots_to_fast_forward = config.fast_forward_slots;
-    if slots_to_fast_forward > 0 {
-        crate::testing_engine::engine::fast_forward_slots(test_context, slots_to_fast_forward)
-            .await;
-    }
-    let transaction = Transaction::new_signed_with_payer(
-        &[execute_order_ix],
-        Some(&payer_signer.pubkey()),
-        &[&payer_signer],
-        recent_blockhash,
-    );
-    testing_context
-        .execute_and_verify_transaction(test_context, transaction, expected_error)
-        .await;
-    if expected_error.is_none() {
-        Some(execute_order_fallback_fixture)
-    } else {
-        None
-    }
-}
-
-pub fn create_execute_order_fallback_fixture(
-    testing_context: &TestingContext,
-    config: &ExecuteOrderInstructionConfig,
-    execute_order_fallback_accounts: &ExecuteOrderFallbackAccounts,
-) -> ExecuteOrderFallbackFixture {
-    let program_id = &testing_context.get_matching_engine_program_id();
-    let cctp_message = Pubkey::find_program_address(
-        &[
-            common::CCTP_MESSAGE_SEED_PREFIX,
-            &execute_order_fallback_accounts.active_auction.to_bytes(),
-        ],
-        program_id,
-    )
-    .0;
-    let token_messenger_minter_sender_authority =
-        Pubkey::find_program_address(&[b"sender_authority"], &TOKEN_MESSENGER_MINTER_PROGRAM_ID).0;
-    let messenger_transmitter_config =
-        Pubkey::find_program_address(&[b"message_transmitter"], &MESSAGE_TRANSMITTER_PROGRAM_ID).0;
-    let token_messenger =
-        Pubkey::find_program_address(&[b"token_messenger"], &TOKEN_MESSENGER_MINTER_PROGRAM_ID).0;
-    let remote_token_messenger = execute_order_fallback_accounts.remote_token_messenger;
-    let token_minter =
-        Pubkey::find_program_address(&[b"token_minter"], &TOKEN_MESSENGER_MINTER_PROGRAM_ID).0;
-    let local_token = Pubkey::find_program_address(
-        &[b"local_token", &USDC_MINT.to_bytes()],
-        &TOKEN_MESSENGER_MINTER_PROGRAM_ID,
-    )
-    .0;
-    let token_messenger_minter_event_authority =
-        &Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], &TOKEN_MESSENGER_MINTER_PROGRAM_ID)
-            .0;
-    let post_message_sequence = wormhole_svm_definitions::find_emitter_sequence_address(
-        &execute_order_fallback_accounts.custodian,
-        &CORE_BRIDGE_PROGRAM_ID,
-    )
-    .0;
-    let post_message_message = wormhole_svm_definitions::find_shim_message_address(
-        &execute_order_fallback_accounts.custodian,
-        &POST_MESSAGE_SHIM_PROGRAM_ID,
-    )
-    .0;
-    let solver = config.actor_enum.get_actor(&testing_context.testing_actors);
-    let executor_token = solver.token_account_address(&config.token_enum).unwrap();
-    ExecuteOrderFallbackFixture {
-        cctp_message,
-        post_message_sequence,
-        post_message_message,
-        accounts: ExecuteOrderFallbackFixtureAccounts {
-            local_token,
-            token_messenger,
-            remote_token_messenger,
-            token_messenger_minter_sender_authority,
-            token_messenger_minter_event_authority: *token_messenger_minter_event_authority,
-            messenger_transmitter_config,
-            token_minter,
-            executor_token,
-        },
+    execute_order_fallback_accounts: &ExecuteOrderShimfulAccounts,
+) -> OrderExecutedState {
+    OrderExecutedState {
+        cctp_message: execute_order_fallback_accounts.cctp_message,
+        post_message_sequence: Some(execute_order_fallback_accounts.post_message_sequence),
+        post_message_message: Some(execute_order_fallback_accounts.post_message_message),
+        actor_enum: config.actor_enum,
     }
 }
 
@@ -226,14 +257,13 @@ pub fn create_execute_order_fallback_fixture(
 /// # Returns
 ///
 /// The execute order shim accounts
-pub fn create_execute_order_shim_accounts<'ix>(
-    execute_order_fallback_accounts: &'ix ExecuteOrderFallbackAccounts,
-    execute_order_fallback_fixture: &'ix ExecuteOrderFallbackFixture,
+fn create_execute_order_shim_accounts<'ix>(
+    execute_order_fallback_accounts: &'ix ExecuteOrderShimfulAccounts,
     clock_id: &'ix Pubkey,
 ) -> ExecuteOrderShimAccounts<'ix> {
     ExecuteOrderShimAccounts {
         signer: &execute_order_fallback_accounts.signer, // 0
-        cctp_message: &execute_order_fallback_fixture.cctp_message, // 1
+        cctp_message: &execute_order_fallback_accounts.cctp_message, // 1
         custodian: &execute_order_fallback_accounts.custodian, // 2
         fast_market_order: &execute_order_fallback_accounts.fast_market_order_address, // 3
         active_auction: &execute_order_fallback_accounts.active_auction, // 4
@@ -241,33 +271,25 @@ pub fn create_execute_order_shim_accounts<'ix>(
         active_auction_config: &execute_order_fallback_accounts.active_auction_config, // 6
         active_auction_best_offer_token: &execute_order_fallback_accounts
             .active_auction_best_offer_token, // 7
-        executor_token: &execute_order_fallback_fixture.accounts.executor_token,       // 8
+        executor_token: &execute_order_fallback_accounts.executor_token,               // 8
         initial_offer_token: &execute_order_fallback_accounts.initial_offer_token,     // 9
         initial_participant: &execute_order_fallback_accounts.initial_participant,     // 10
         to_router_endpoint: &execute_order_fallback_accounts.to_router_endpoint,       // 11
         post_message_shim_program: &POST_MESSAGE_SHIM_PROGRAM_ID,                      // 12
-        core_bridge_emitter_sequence: &execute_order_fallback_fixture.post_message_sequence, // 13
-        post_shim_message: &execute_order_fallback_fixture.post_message_message,       // 14
+        core_bridge_emitter_sequence: &execute_order_fallback_accounts.post_message_sequence, // 13
+        post_shim_message: &execute_order_fallback_accounts.post_message_message,      // 14
         cctp_deposit_for_burn_mint: &USDC_MINT,                                        // 15
         cctp_deposit_for_burn_token_messenger_minter_sender_authority:
-            &execute_order_fallback_fixture
-                .accounts
-                .token_messenger_minter_sender_authority, // 16
-        cctp_deposit_for_burn_message_transmitter_config: &execute_order_fallback_fixture
-            .accounts
+            &execute_order_fallback_accounts.token_messenger_minter_sender_authority, // 16
+        cctp_deposit_for_burn_message_transmitter_config: &execute_order_fallback_accounts
             .messenger_transmitter_config, // 17
-        cctp_deposit_for_burn_token_messenger: &execute_order_fallback_fixture
-            .accounts
-            .token_messenger, // 18
-        cctp_deposit_for_burn_remote_token_messenger: &execute_order_fallback_fixture
-            .accounts
+        cctp_deposit_for_burn_token_messenger: &execute_order_fallback_accounts.token_messenger, // 18
+        cctp_deposit_for_burn_remote_token_messenger: &execute_order_fallback_accounts
             .remote_token_messenger, // 19
-        cctp_deposit_for_burn_token_minter: &execute_order_fallback_fixture.accounts.token_minter, // 20
-        cctp_deposit_for_burn_local_token: &execute_order_fallback_fixture.accounts.local_token, // 21
+        cctp_deposit_for_burn_token_minter: &execute_order_fallback_accounts.token_minter, // 20
+        cctp_deposit_for_burn_local_token: &execute_order_fallback_accounts.local_token,   // 21
         cctp_deposit_for_burn_token_messenger_minter_event_authority:
-            &execute_order_fallback_fixture
-                .accounts
-                .token_messenger_minter_event_authority, // 22
+            &execute_order_fallback_accounts.token_messenger_minter_event_authority, // 22
         cctp_deposit_for_burn_token_messenger_minter_program: &TOKEN_MESSENGER_MINTER_PROGRAM_ID, // 23
         cctp_deposit_for_burn_message_transmitter_program: &MESSAGE_TRANSMITTER_PROGRAM_ID, // 24
         core_bridge_program: &CORE_BRIDGE_PROGRAM_ID,                                       // 25
@@ -278,34 +300,4 @@ pub fn create_execute_order_shim_accounts<'ix>(
         token_program: &spl_token::ID,                                                      // 30
         clock: clock_id,                                                                    // 31
     }
-}
-
-pub async fn execute_order_shimful_test(
-    testing_context: &TestingContext,
-    test_context: &mut ProgramTestContext,
-    current_state: &TestingEngineState,
-    config: &ExecuteOrderInstructionConfig,
-) -> Option<ExecuteOrderFallbackFixture> {
-    let expected_error = config.expected_error();
-    let fixture_accounts = testing_context
-        .get_fixture_accounts()
-        .expect("Pre-made fixture accounts not found");
-    let payer_signer = config
-        .payer_signer
-        .clone()
-        .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
-    let execute_order_fallback_accounts = ExecuteOrderFallbackAccounts::new(
-        current_state,
-        &payer_signer.pubkey(),
-        &fixture_accounts,
-        config.fast_market_order_address,
-    );
-    execute_order_shimful(
-        testing_context,
-        test_context,
-        config,
-        &execute_order_fallback_accounts,
-        expected_error,
-    )
-    .await
 }

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_execute_order.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_execute_order.rs
@@ -215,6 +215,17 @@ pub fn create_execute_order_fallback_fixture(
     }
 }
 
+/// Create the execute order shim accounts
+///
+/// # Arguments
+///
+/// * `execute_order_fallback_accounts` - The execute order fallback accounts
+/// * `execute_order_fallback_fixture` - The execute order fallback fixture
+/// * `clock_id` - The clock id
+///
+/// # Returns
+///
+/// The execute order shim accounts
 pub fn create_execute_order_shim_accounts<'ix>(
     execute_order_fallback_accounts: &'ix ExecuteOrderFallbackAccounts,
     execute_order_fallback_fixture: &'ix ExecuteOrderFallbackFixture,

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_make_offer.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_make_offer.rs
@@ -76,7 +76,6 @@ pub async fn place_initial_offer_shimful(
             1000000000,
         )
         .await;
-
     testing_context
         .execute_and_verify_transaction(test_context, transaction, expected_error)
         .await;
@@ -244,10 +243,13 @@ impl PlaceInitialOfferShimfulAccounts {
             .payer_signer
             .clone()
             .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
-        let close_account_refund_recipient = current_state
-            .fast_market_order()
-            .unwrap()
-            .close_account_refund_recipient;
+        let close_account_refund_recipient =
+            config.close_account_refund_recipient.unwrap_or_else(|| {
+                current_state
+                    .fast_market_order()
+                    .unwrap()
+                    .close_account_refund_recipient
+            });
         let fast_market_order = match &config.fast_market_order_address {
             Some(fast_market_order_address) => *fast_market_order_address,
             None => {

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_make_offer.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_make_offer.rs
@@ -21,18 +21,15 @@ use solana_sdk::{pubkey::Pubkey, signer::Signer};
 ///
 /// # Arguments
 ///
-/// * `testing_context` - The testing context
-/// * `payer_signer` - The payer signer
-/// * `vaa_data` - The vaa data (not posted)
-/// * `solver` - The solver actor that will place the initial offer
-/// * `fast_market_order_account` - The fast market order account pubkey created by the create fast market order shim instruction
-/// * `auction_accounts` - The auction accounts (see utils/auction.rs)
-/// * `offer_price` - The offer price in the units of the offer token
-/// * `expected_error` - The expected error (None if no error is expected)
+/// * `testing_context` - The testing context of the testing engine
+/// * `test_context` - Mutable reference to the test context
+/// * `current_state` - The current state of the testing engine
+/// * `config` - The config of the place initial offer instruction
+/// * `expected_error` - The expected error of the place initial offer instruction
 ///
 /// # Returns
 ///
-/// * `Option<InitialOfferPlacedState>` - An auction state with the initial offer placed. None if an error is expected.
+/// * `TestingEngineState` - The state of the testing engine after the place initial offer instruction
 ///
 /// # Asserts
 ///
@@ -72,8 +69,8 @@ pub async fn place_initial_offer_shimful(
             &[place_initial_offer_ix],
             Some(&payer_signer.pubkey()),
             &[&payer_signer],
-            1000000000,
-            1000000000,
+            None,
+            None,
         )
         .await;
     testing_context

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_make_offer.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_make_offer.rs
@@ -90,6 +90,20 @@ pub async fn place_initial_offer_shimful(
     .await
 }
 
+/// Evaluate the place initial offer shimful state
+///
+/// # Arguments
+///
+/// * `testing_context` - The testing context
+/// * `test_context` - The test context
+/// * `current_state` - The current state
+/// * `config` - The config
+/// * `actor_usdc_balance_before` - The actor USDC balance before
+/// * `place_initial_offer_accounts` - The place initial offer shimful accounts
+///
+/// # Returns
+///
+/// The testing engine state after the place initial offer shimful instruction
 pub async fn evaluate_place_initial_offer_shimful_state(
     testing_context: &TestingContext,
     test_context: &mut ProgramTestContext,
@@ -170,6 +184,20 @@ pub async fn evaluate_place_initial_offer_shimful_state(
     current_state.clone()
 }
 
+/// Place the initial offer shimful instruction
+///
+/// Creates the place initial offer shimful instruction
+///
+/// # Arguments
+///
+/// * `testing_context` - The testing context
+/// * `test_context` - The test context
+/// * `current_state` - The current state
+/// * `config` - The config
+///
+/// # Returns
+///
+/// The place initial offer shimful instruction
 pub async fn place_initial_offer_shimful_instruction(
     testing_context: &TestingContext,
     test_context: &mut ProgramTestContext,

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_make_offer.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_make_offer.rs
@@ -1,4 +1,6 @@
-use crate::testing_engine::config::{ExpectedError, PlaceInitialOfferInstructionConfig};
+use crate::testing_engine::config::{
+    ExpectedError, InstructionConfig, PlaceInitialOfferInstructionConfig,
+};
 use crate::testing_engine::state::{InitialOfferPlacedState, TestingEngineState};
 use crate::utils::auction::AuctionAccounts;
 
@@ -13,7 +15,7 @@ use matching_engine::state::Auction;
 use solana_program_test::ProgramTestContext;
 
 use super::fast_market_order_shim::create_fast_market_order_state_from_vaa_data;
-use solana_sdk::{pubkey::Pubkey, signer::Signer, transaction::Transaction};
+use solana_sdk::{pubkey::Pubkey, signer::Signer};
 
 /// Places an initial offer using the fallback program. The vaa is constructed from a passed in PostedVaaData struct. The nonce is forced to 0.
 ///
@@ -36,144 +38,73 @@ use solana_sdk::{pubkey::Pubkey, signer::Signer, transaction::Transaction};
 ///
 /// * The expected error is reached
 /// * If successful, the solver's USDC balance should decrease by the offer price
-pub async fn place_initial_offer_fallback(
+pub async fn place_initial_offer_shimful(
     testing_context: &TestingContext,
     test_context: &mut ProgramTestContext,
     current_state: &TestingEngineState,
     config: &PlaceInitialOfferInstructionConfig,
     expected_error: Option<&ExpectedError>,
-) -> Option<InitialOfferPlacedState> {
+) -> TestingEngineState {
     let payer_signer = config
         .payer_signer
         .clone()
         .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
-    let close_account_refund_recipient = current_state
-        .fast_market_order()
-        .unwrap()
-        .close_account_refund_recipient;
-    let fast_market_order_address = match &config.fast_market_order_address {
-        Some(fast_market_order_address) => *fast_market_order_address,
-        None => {
-            current_state
-                .fast_market_order()
-                .expect("Fast market order is not created")
-                .fast_market_order_address
-        }
-    };
-    let auction_config_address = current_state.auction_config_address().unwrap();
-    let custodian_address = current_state.custodian_address().unwrap();
-    let program_id = testing_context.get_matching_engine_program_id();
-    let fast_transfer_vaa = &current_state
-        .base()
-        .vaas
-        .get(config.test_vaa_pair_index)
-        .expect("Failed to get vaa pair")
-        .fast_transfer_vaa;
-    let vaa_data = fast_transfer_vaa.get_vaa_data();
-    let fast_market_order =
-        create_fast_market_order_state_from_vaa_data(vaa_data, close_account_refund_recipient);
-    let offer_price = config.offer_price;
-    let actor_enum = config.actor;
+    let place_initial_offer_accounts =
+        PlaceInitialOfferShimfulAccounts::new(testing_context, current_state, config);
+
     let offer_actor = config.actor.get_actor(&testing_context.testing_actors);
-    let offer_token = match &config.custom_accounts {
-        Some(custom_accounts) => match custom_accounts.offer_token_address {
-            Some(offer_token_address) => offer_token_address,
-            None => offer_actor
-                .token_account_address(&config.spl_token_enum)
-                .unwrap(),
-        },
-        None => offer_actor
-            .token_account_address(&config.spl_token_enum)
-            .unwrap(),
-    };
-    let auction_address = Pubkey::find_program_address(
-        &[Auction::SEED_PREFIX, &fast_market_order.digest()],
-        &program_id,
-    )
-    .0;
-    let auction_custody_token_address = Pubkey::find_program_address(
-        &[
-            matching_engine::AUCTION_CUSTODY_TOKEN_SEED_PREFIX,
-            auction_address.as_ref(),
-        ],
-        &program_id,
-    )
-    .0;
-
-    // Approve the transfer authority
-    let transfer_authority = Pubkey::find_program_address(
-        &[
-            common::TRANSFER_AUTHORITY_SEED_PREFIX,
-            &auction_address.to_bytes(),
-            &offer_price.to_be_bytes(),
-        ],
-        &program_id,
-    )
-    .0;
-
-    offer_actor
-        .approve_spl_token(
-            test_context,
-            &transfer_authority,
-            420_000__000_000,
-            &config.spl_token_enum,
-        )
-        .await;
 
     let actor_usdc_balance_before = offer_actor
         .get_token_account_balance(test_context, &config.spl_token_enum)
         .await;
 
-    let place_initial_offer_ix_data = PlaceInitialOfferCctpShimFallbackData { offer_price };
+    let place_initial_offer_ix = place_initial_offer_shimful_instruction(
+        testing_context,
+        test_context,
+        current_state,
+        config,
+    )
+    .await;
 
-    let (from_router_endpoint, to_router_endpoint) =
-        config.get_from_and_to_router_endpoints(current_state);
-
-    let usdc_mint_address = match &config.custom_accounts {
-        Some(custom_accounts) => match custom_accounts.mint_address {
-            Some(usdc_mint_address) => usdc_mint_address,
-            None => testing_context.get_usdc_mint_address(),
-        },
-        None => testing_context.get_usdc_mint_address(),
-    };
-
-    let place_initial_offer_ix_accounts = PlaceInitialOfferCctpShimFallbackAccounts {
-        signer: &payer_signer.pubkey(),
-        transfer_authority: &transfer_authority,
-        custodian: &custodian_address,
-        auction_config: &auction_config_address,
-        from_endpoint: &from_router_endpoint,
-        to_endpoint: &to_router_endpoint,
-        fast_market_order: &fast_market_order_address,
-        auction: &auction_address,
-        offer_token: &offer_token,
-        auction_custody_token: &auction_custody_token_address,
-        usdc: &usdc_mint_address,
-        system_program: &solana_program::system_program::ID,
-        token_program: &anchor_spl::token::spl_token::ID,
-    };
-    let place_initial_offer_ix = PlaceInitialOfferCctpShimFallback {
-        program_id: &program_id,
-        accounts: place_initial_offer_ix_accounts,
-        data: place_initial_offer_ix_data,
-    }
-    .instruction();
-
-    let recent_blockhash = testing_context
-        .get_new_latest_blockhash(test_context)
-        .await
-        .unwrap();
-
-    let transaction = Transaction::new_signed_with_payer(
-        &[place_initial_offer_ix],
-        Some(&payer_signer.pubkey()),
-        &[&payer_signer],
-        recent_blockhash,
-    );
+    let transaction = testing_context
+        .create_transaction(
+            test_context,
+            &[place_initial_offer_ix],
+            Some(&payer_signer.pubkey()),
+            &[&payer_signer],
+            1000000000,
+            1000000000,
+        )
+        .await;
 
     testing_context
         .execute_and_verify_transaction(test_context, transaction, expected_error)
         .await;
+    evaluate_place_initial_offer_shimful_state(
+        testing_context,
+        test_context,
+        current_state,
+        config,
+        actor_usdc_balance_before,
+        &place_initial_offer_accounts,
+    )
+    .await
+}
+
+pub async fn evaluate_place_initial_offer_shimful_state(
+    testing_context: &TestingContext,
+    test_context: &mut ProgramTestContext,
+    current_state: &TestingEngineState,
+    config: &PlaceInitialOfferInstructionConfig,
+    actor_usdc_balance_before: u64,
+    place_initial_offer_accounts: &PlaceInitialOfferShimfulAccounts,
+) -> TestingEngineState {
+    let expected_error = config.expected_error();
+    let offer_actor = config.actor.get_actor(&testing_context.testing_actors);
+    let payer_signer = config
+        .payer_signer
+        .clone()
+        .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
     if expected_error.is_none() {
         let actor_usdc_balance_after = offer_actor
             .get_token_account_balance(test_context, &config.spl_token_enum)
@@ -183,42 +114,217 @@ pub async fn place_initial_offer_fallback(
             "Solver USDC balance should have decreased"
         );
         let new_active_auction_state = utils::auction::ActiveAuctionState {
-            auction_address,
-            auction_custody_token_address,
-            auction_config_address,
+            auction_address: place_initial_offer_accounts.auction,
+            auction_custody_token_address: place_initial_offer_accounts.auction_custody_token,
+            auction_config_address: place_initial_offer_accounts.auction_config,
             initial_offer: utils::auction::AuctionOffer {
-                actor: actor_enum,
+                actor: config.actor,
                 participant: payer_signer.pubkey(),
-                offer_token,
-                offer_price,
+                offer_token: place_initial_offer_accounts.offer_token,
+                offer_price: config.offer_price,
             },
             best_offer: utils::auction::AuctionOffer {
-                actor: actor_enum,
+                actor: config.actor,
                 participant: payer_signer.pubkey(),
-                offer_token,
-                offer_price,
+                offer_token: place_initial_offer_accounts.offer_token,
+                offer_price: config.offer_price,
             },
             spl_token_enum: config.spl_token_enum.clone(),
         };
         let new_auction_state =
             utils::auction::AuctionState::Active(Box::new(new_active_auction_state));
-        Some(InitialOfferPlacedState {
+        let initial_offer_placed_state = InitialOfferPlacedState {
             auction_state: new_auction_state,
             auction_accounts: AuctionAccounts::new(
-                Some(fast_transfer_vaa.get_vaa_pubkey()),
+                None,
                 offer_actor.clone(),
                 current_state.close_account_refund_recipient(),
-                auction_config_address,
+                place_initial_offer_accounts.auction_config,
                 &current_state
                     .router_endpoints()
                     .expect("Router endpoints are not created")
                     .endpoints,
-                custodian_address,
+                place_initial_offer_accounts.custodian,
                 config.spl_token_enum.clone(),
                 current_state.base().transfer_direction,
             ),
-        })
-    } else {
-        None
+        };
+        let active_auction_state = initial_offer_placed_state
+            .auction_state
+            .get_active_auction()
+            .unwrap();
+        active_auction_state
+            .verify_auction(&testing_context, test_context)
+            .await
+            .expect("Could not verify auction");
+        let auction_accounts = initial_offer_placed_state.auction_accounts;
+        return TestingEngineState::InitialOfferPlaced {
+            base: current_state.base().clone(),
+            initialized: current_state.initialized().unwrap().clone(),
+            router_endpoints: current_state.router_endpoints().unwrap().clone(),
+            fast_market_order: current_state.fast_market_order().cloned(),
+            auction_state: initial_offer_placed_state.auction_state,
+            auction_accounts,
+            order_prepared: current_state.order_prepared().cloned(),
+        };
+    }
+    current_state.clone()
+}
+
+pub async fn place_initial_offer_shimful_instruction(
+    testing_context: &TestingContext,
+    test_context: &mut ProgramTestContext,
+    current_state: &TestingEngineState,
+    config: &PlaceInitialOfferInstructionConfig,
+) -> solana_program::instruction::Instruction {
+    let place_initial_offer_accounts =
+        PlaceInitialOfferShimfulAccounts::new(testing_context, current_state, config);
+
+    let offer_actor = config.actor.get_actor(&testing_context.testing_actors);
+
+    offer_actor
+        .approve_spl_token(
+            test_context,
+            &place_initial_offer_accounts.transfer_authority,
+            420_000__000_000,
+            &config.spl_token_enum,
+        )
+        .await;
+
+    let place_initial_offer_ix_data = PlaceInitialOfferCctpShimFallbackData {
+        offer_price: config.offer_price,
+    };
+
+    let place_initial_offer_ix_accounts = PlaceInitialOfferCctpShimFallbackAccounts {
+        signer: &place_initial_offer_accounts.signer,
+        transfer_authority: &place_initial_offer_accounts.transfer_authority,
+        custodian: &place_initial_offer_accounts.custodian,
+        auction_config: &place_initial_offer_accounts.auction_config,
+        from_endpoint: &place_initial_offer_accounts.from_endpoint,
+        to_endpoint: &place_initial_offer_accounts.to_endpoint,
+        fast_market_order: &place_initial_offer_accounts.fast_market_order,
+        auction: &place_initial_offer_accounts.auction,
+        offer_token: &place_initial_offer_accounts.offer_token,
+        auction_custody_token: &place_initial_offer_accounts.auction_custody_token,
+        usdc: &place_initial_offer_accounts.usdc,
+        system_program: &place_initial_offer_accounts.system_program,
+        token_program: &place_initial_offer_accounts.token_program,
+    };
+    PlaceInitialOfferCctpShimFallback {
+        program_id: &testing_context.get_matching_engine_program_id(),
+        accounts: place_initial_offer_ix_accounts,
+        data: place_initial_offer_ix_data,
+    }
+    .instruction()
+}
+
+pub struct PlaceInitialOfferShimfulAccounts {
+    pub signer: Pubkey,
+    pub transfer_authority: Pubkey,
+    pub custodian: Pubkey,
+    pub auction_config: Pubkey,
+    pub from_endpoint: Pubkey,
+    pub to_endpoint: Pubkey,
+    pub fast_market_order: Pubkey,
+    pub auction: Pubkey,
+    pub offer_token: Pubkey,
+    pub auction_custody_token: Pubkey,
+    pub usdc: Pubkey,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+}
+
+impl PlaceInitialOfferShimfulAccounts {
+    pub fn new(
+        testing_context: &TestingContext,
+        current_state: &TestingEngineState,
+        config: &PlaceInitialOfferInstructionConfig,
+    ) -> Self {
+        let payer_signer = config
+            .payer_signer
+            .clone()
+            .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
+        let close_account_refund_recipient = current_state
+            .fast_market_order()
+            .unwrap()
+            .close_account_refund_recipient;
+        let fast_market_order = match &config.fast_market_order_address {
+            Some(fast_market_order_address) => *fast_market_order_address,
+            None => {
+                current_state
+                    .fast_market_order()
+                    .expect("Fast market order is not created")
+                    .fast_market_order_address
+            }
+        };
+        let auction_config = current_state.auction_config_address().unwrap();
+        let custodian = current_state.custodian_address().unwrap();
+        let program_id = testing_context.get_matching_engine_program_id();
+        let fast_transfer_vaa = &current_state
+            .base()
+            .vaas
+            .get(config.test_vaa_pair_index)
+            .expect("Failed to get vaa pair")
+            .fast_transfer_vaa;
+        let vaa_data = fast_transfer_vaa.get_vaa_data();
+        let fast_market_order_state =
+            create_fast_market_order_state_from_vaa_data(vaa_data, close_account_refund_recipient);
+        let offer_actor = config.actor.get_actor(&testing_context.testing_actors);
+        let offer_token = match &config.custom_accounts {
+            Some(custom_accounts) => match custom_accounts.offer_token_address {
+                Some(offer_token_address) => offer_token_address,
+                None => offer_actor
+                    .token_account_address(&config.spl_token_enum)
+                    .unwrap(),
+            },
+            None => offer_actor
+                .token_account_address(&config.spl_token_enum)
+                .unwrap(),
+        };
+        let auction = Pubkey::find_program_address(
+            &[Auction::SEED_PREFIX, &fast_market_order_state.digest()],
+            &program_id,
+        )
+        .0;
+        let auction_custody_token = Pubkey::find_program_address(
+            &[
+                matching_engine::AUCTION_CUSTODY_TOKEN_SEED_PREFIX,
+                auction.as_ref(),
+            ],
+            &program_id,
+        )
+        .0;
+        let transfer_authority = Pubkey::find_program_address(
+            &[
+                common::TRANSFER_AUTHORITY_SEED_PREFIX,
+                &auction.to_bytes(),
+                &config.offer_price.to_be_bytes(),
+            ],
+            &program_id,
+        )
+        .0;
+        let (from_endpoint, to_endpoint) = config.get_from_and_to_router_endpoints(current_state);
+        let usdc = match &config.custom_accounts {
+            Some(custom_accounts) => match custom_accounts.mint_address {
+                Some(usdc_mint_address) => usdc_mint_address,
+                None => testing_context.get_usdc_mint_address(),
+            },
+            None => testing_context.get_usdc_mint_address(),
+        };
+        Self {
+            signer: payer_signer.pubkey(),
+            transfer_authority,
+            custodian,
+            auction_config,
+            from_endpoint,
+            to_endpoint,
+            fast_market_order,
+            auction,
+            offer_token,
+            auction_custody_token,
+            usdc,
+            system_program: solana_program::system_program::ID,
+            token_program: anchor_spl::token::spl_token::ID,
+        }
     }
 }

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_prepare_order_response.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_prepare_order_response.rs
@@ -145,15 +145,38 @@ impl PrepareOrderResponseShimAccountsFixture {
     }
 }
 
-pub struct PrepareOrderResponseShimDataFixture {
+/// Prepare order response shim data helper
+///
+/// This struct is a helper struct used to create the data for the prepare order response instruction
+///
+/// # Fields
+///
+/// * `encoded_cctp_message` - The encoded CCTP message
+/// * `cctp_attestation` - The CCTP attestation
+/// * `finalized_vaa_message_args` - The finalized VAA message args
+/// * `fast_market_order` - The fast market order
+pub struct PrepareOrderResponseShimDataHelper {
     pub encoded_cctp_message: Vec<u8>,
     pub cctp_attestation: Vec<u8>,
     pub finalized_vaa_message_args: FinalizedVaaMessageArgs,
     pub fast_market_order: FastMarketOrderState,
 }
 
-// Helper struct for creating the data for the prepare order response instruction
-impl PrepareOrderResponseShimDataFixture {
+impl PrepareOrderResponseShimDataHelper {
+    /// Create a new prepare order response shim data helper
+    ///
+    /// # Arguments
+    ///
+    /// * `encoded_cctp_message` - The encoded CCTP message
+    /// * `cctp_attestation` - The CCTP attestation
+    /// * `consistency_level` - The consistency level
+    /// * `base_fee` - The base fee
+    /// * `fast_market_order` - The fast market order
+    /// * `guardian_set_bump` - The guardian set bump
+    ///
+    /// # Returns
+    ///
+    /// The prepare order response shim data helper
     pub fn new(
         encoded_cctp_message: Vec<u8>,
         cctp_attestation: Vec<u8>,
@@ -183,12 +206,25 @@ impl PrepareOrderResponseShimDataFixture {
 }
 
 /// Executes the instruction that prepares the order response for the CCTP shim
+///
+/// # Arguments
+///
+/// * `testing_context` - The testing context
+/// * `test_context` - The test context
+/// * `payer_signer` - The payer signer
+/// * `accounts` - The prepare order response shim accounts
+/// * `data` - The prepare order response shim data
+/// * `expected_error` - The expected error
+///
+/// # Returns
+///
+/// The prepare order response shim fixture
 pub async fn prepare_order_response_cctp_shim(
     testing_context: &TestingContext,
     test_context: &mut ProgramTestContext,
     payer_signer: &Rc<Keypair>,
     accounts: PrepareOrderResponseShimAccountsFixture,
-    data: PrepareOrderResponseShimDataFixture,
+    data: PrepareOrderResponseShimDataHelper,
     expected_error: Option<&ExpectedError>,
 ) -> Option<PrepareOrderResponseShimFixture> {
     let matching_engine_program_id = &testing_context.get_matching_engine_program_id();
@@ -280,6 +316,20 @@ pub async fn prepare_order_response_cctp_shim(
     }
 }
 
+/// Prepare order response test
+///
+/// Executes the prepare order response instruction in a testing context
+///
+/// # Arguments
+///
+/// * `testing_context` - The testing context
+/// * `test_context` - The test context
+/// * `config` - The prepare order response instruction config
+/// * `current_state` - The current state
+///
+/// # Returns
+///
+/// The prepare order response shim fixture (none if failed)
 pub async fn prepare_order_response_test(
     testing_context: &TestingContext,
     test_context: &mut ProgramTestContext,
@@ -337,7 +387,7 @@ pub async fn prepare_order_response_test(
         .unwrap();
 
     let deposit_base_fee = utils::cctp_message::get_deposit_base_fee(&deposit);
-    let prepare_order_response_cctp_shim_data = PrepareOrderResponseShimDataFixture::new(
+    let prepare_order_response_cctp_shim_data = PrepareOrderResponseShimDataHelper::new(
         cctp_token_burn_message.encoded_cctp_burn_message,
         cctp_token_burn_message.cctp_attestation,
         deposit_vaa_data.consistency_level,

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_prepare_order_response.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_prepare_order_response.rs
@@ -1,8 +1,6 @@
-use crate::testing_engine::config::{
-    ExpectedError, InstructionConfig, PrepareOrderResponseInstructionConfig,
-};
+use crate::testing_engine::config::{InstructionConfig, PrepareOrderResponseInstructionConfig};
 use crate::testing_engine::setup::{TestingContext, TransferDirection};
-use crate::testing_engine::state::TestingEngineState;
+use crate::testing_engine::state::{OrderPreparedState, TestingEngineState};
 
 use super::super::utils;
 use super::verify_shim::GuardianSignatureInfo;
@@ -19,14 +17,263 @@ use matching_engine::fallback::prepare_order_response::{
 use matching_engine::state::{FastMarketOrder as FastMarketOrderState, PreparedOrderResponse};
 use matching_engine::CCTP_MINT_RECIPIENT;
 use solana_program_test::ProgramTestContext;
-use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use solana_sdk::transaction::Transaction;
-use std::rc::Rc;
 use utils::cctp_message::{CctpMessageDecoded, UsedNonces};
 use wormhole_svm_definitions::EVENT_AUTHORITY_SEED;
 
-pub struct PrepareOrderResponseShimAccountsFixture {
+/// Prepare order response cctp shimful
+///
+/// Executes the prepare order response instruction in a testing context
+///
+/// # Arguments
+///
+/// * `testing_context` - The testing context
+/// * `test_context` - The test context
+/// * `config` - The prepare order response instruction config
+/// * `current_state` - The current state
+///
+/// # Returns
+///
+/// The prepare order response shim fixture (none if failed)
+pub async fn prepare_order_response_cctp_shimful(
+    testing_context: &TestingContext,
+    test_context: &mut ProgramTestContext,
+    config: &PrepareOrderResponseInstructionConfig,
+    current_state: &TestingEngineState,
+) -> TestingEngineState {
+    let payer_signer = config
+        .payer_signer
+        .clone()
+        .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
+    let data = PrepareOrderResponseShimDataHelper::new(
+        testing_context,
+        test_context,
+        current_state,
+        config,
+    )
+    .await;
+    let cctp_message_decoded = data.decode_cctp_message();
+    let accounts = PrepareOrderResponseShimAccountsHelper::new(
+        testing_context,
+        config,
+        current_state,
+        &cctp_message_decoded,
+        &data,
+    );
+
+    let ix_accounts = PrepareOrderResponseCctpShimAccounts {
+        signer: &accounts.signer,
+        custodian: &accounts.custodian,
+        fast_market_order: &accounts.fast_market_order,
+        from_endpoint: &accounts.from_endpoint,
+        to_endpoint: &accounts.to_endpoint,
+        prepared_order_response: &accounts.prepared_order_response,
+        prepared_custody_token: &accounts.prepared_custody_token,
+        base_fee_token: &accounts.base_fee_token,
+        usdc: &accounts.usdc,
+        cctp_mint_recipient: &accounts.cctp_mint_recipient,
+        cctp_message_transmitter_authority: &accounts.cctp_message_transmitter_authority,
+        cctp_message_transmitter_config: &accounts.cctp_message_transmitter_config,
+        cctp_used_nonces: &accounts.cctp_used_nonces,
+        cctp_message_transmitter_event_authority: &accounts
+            .cctp_message_transmitter_event_authority,
+        cctp_token_messenger: &accounts.cctp_token_messenger,
+        cctp_remote_token_messenger: &accounts.cctp_remote_token_messenger,
+        cctp_token_minter: &accounts.cctp_token_minter,
+        cctp_local_token: &accounts.cctp_local_token,
+        cctp_token_pair: &accounts.cctp_token_pair,
+        cctp_token_messenger_minter_event_authority: &accounts
+            .cctp_token_messenger_minter_event_authority,
+        cctp_token_messenger_minter_custody_token: &accounts
+            .cctp_token_messenger_minter_custody_token,
+        cctp_token_messenger_minter_program: &accounts.cctp_token_messenger_minter_program,
+        cctp_message_transmitter_program: &accounts.cctp_message_transmitter_program,
+        guardian_set: &accounts.guardian_set,
+        guardian_set_signatures: &accounts.guardian_set_signatures,
+        verify_shim_program: &wormhole_svm_definitions::solana::VERIFY_VAA_SHIM_PROGRAM_ID,
+        token_program: &spl_token::ID,
+        system_program: &solana_program::system_program::ID,
+    };
+
+    let finalized_vaa_message_args = data.finalized_vaa_message_args;
+    let data = PrepareOrderResponseCctpShimData {
+        encoded_cctp_message: data.encoded_cctp_message,
+        cctp_attestation: data.cctp_attestation,
+        finalized_vaa_message_args,
+    };
+    let program_id = &testing_context.get_matching_engine_program_id();
+    let prepare_order_response_cctp_shim_ix = PrepareOrderResponseCctpShimIx {
+        program_id,
+        accounts: ix_accounts,
+        data,
+    }
+    .instruction();
+
+    let recent_blockhash = testing_context
+        .get_new_latest_blockhash(test_context)
+        .await
+        .expect("Failed to get new latest blockhash");
+    let transaction = Transaction::new_signed_with_payer(
+        &[prepare_order_response_cctp_shim_ix],
+        Some(&payer_signer.pubkey()),
+        &[&payer_signer],
+        recent_blockhash,
+    );
+
+    let expected_error = config.expected_error();
+    testing_context
+        .execute_and_verify_transaction(test_context, transaction, expected_error)
+        .await;
+    if config.expected_error.is_none() {
+        let auction_accounts = config
+            .overwrite_auction_accounts
+            .as_ref()
+            .unwrap_or_else(|| {
+                current_state
+                    .auction_accounts()
+                    .expect("Auction accounts not found")
+            });
+
+        let order_prepared_state = OrderPreparedState {
+            prepared_order_response_address: accounts.prepared_order_response,
+            prepared_custody_token: accounts.prepared_custody_token,
+            base_fee_token: accounts.base_fee_token,
+            actor_enum: config.actor_enum,
+        };
+        TestingEngineState::OrderPrepared {
+            base: current_state.base().clone(),
+            initialized: current_state.initialized().unwrap().clone(),
+            router_endpoints: current_state.router_endpoints().unwrap().clone(),
+            fast_market_order: current_state.fast_market_order().cloned(),
+            auction_state: current_state.auction_state().clone(),
+            order_prepared: order_prepared_state,
+            auction_accounts: auction_accounts.clone(),
+        }
+    } else {
+        current_state.clone()
+    }
+}
+
+/// Prepare order response shim data helper
+///
+/// This struct is a helper struct used to create the data for the prepare order response instruction
+///
+/// # Fields
+///
+/// * `encoded_cctp_message` - The encoded CCTP message
+/// * `cctp_attestation` - The CCTP attestation
+/// * `finalized_vaa_message_args` - The finalized VAA message args
+/// * `fast_market_order` - The fast market order
+struct PrepareOrderResponseShimDataHelper {
+    pub encoded_cctp_message: Vec<u8>,
+    pub cctp_attestation: Vec<u8>,
+    pub finalized_vaa_message_args: FinalizedVaaMessageArgs,
+    pub fast_market_order: FastMarketOrderState,
+    pub guardian_signature_info: GuardianSignatureInfo,
+}
+
+/// A helper struct for the data for the prepare order response shimful instruction that disregards the lifetime
+impl PrepareOrderResponseShimDataHelper {
+    /// Create a new prepare order response shim data helper
+    ///
+    /// # Arguments
+    ///
+    /// * `encoded_cctp_message` - The encoded CCTP message
+    /// * `cctp_attestation` - The CCTP attestation
+    /// * `consistency_level` - The consistency level
+    /// * `base_fee` - The base fee
+    /// * `fast_market_order` - The fast market order
+    /// * `guardian_set_bump` - The guardian set bump
+    ///
+    /// # Returns
+    ///
+    /// The prepare order response shim data helper
+    pub async fn new(
+        testing_context: &TestingContext,
+        test_context: &mut ProgramTestContext,
+        current_state: &TestingEngineState,
+        config: &PrepareOrderResponseInstructionConfig,
+    ) -> Self {
+        let payer_signer = config
+            .payer_signer
+            .clone()
+            .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
+        let deposit_vaa = current_state
+            .get_test_vaa_pair(config.vaa_index)
+            .deposit_vaa
+            .clone();
+        let deposit_vaa_data = deposit_vaa.get_vaa_data();
+        let deposit = deposit_vaa
+            .payload_deserialized
+            .clone()
+            .unwrap()
+            .get_deposit()
+            .unwrap();
+        let finalized_vaa_data = current_state
+            .get_test_vaa_pair(config.vaa_index)
+            .get_finalized_vaa_data()
+            .clone();
+
+        let fast_market_order_state = current_state
+            .fast_market_order()
+            .expect("could not find fast market order")
+            .fast_market_order;
+
+        let cctp_token_burn_message = utils::cctp_message::craft_cctp_token_burn_message(
+            testing_context,
+            test_context,
+            current_state,
+            config.vaa_index,
+        )
+        .await
+        .unwrap();
+        cctp_token_burn_message
+            .verify_cctp_message(&fast_market_order_state)
+            .unwrap();
+
+        let deposit_base_fee = utils::cctp_message::get_deposit_base_fee(&deposit);
+
+        let core_bridge_program_id = &testing_context.get_wormhole_program_id();
+
+        let guardian_signature_info = super::verify_shim::create_guardian_signatures(
+            testing_context,
+            test_context,
+            &payer_signer,
+            &finalized_vaa_data,
+            core_bridge_program_id,
+            None,
+        )
+        .await
+        .unwrap();
+
+        Self {
+            encoded_cctp_message: cctp_token_burn_message.encoded_cctp_burn_message,
+            cctp_attestation: cctp_token_burn_message.cctp_attestation,
+            finalized_vaa_message_args: FinalizedVaaMessageArgs {
+                consistency_level: deposit_vaa_data.consistency_level,
+                base_fee: deposit_base_fee,
+                guardian_set_bump: guardian_signature_info.guardian_set_bump,
+            },
+            fast_market_order: fast_market_order_state,
+            guardian_signature_info,
+        }
+    }
+    pub fn decode_cctp_message(&self) -> CctpMessageDecoded {
+        let cctp_message_decoded = CctpMessage::parse(&self.encoded_cctp_message[..]).unwrap();
+        CctpMessageDecoded {
+            nonce: cctp_message_decoded.nonce(),
+            source_domain: cctp_message_decoded.source_domain(),
+        }
+    }
+}
+
+/// Prepare order response shim accounts helper
+///
+/// A helper struct for the accounts for the prepare order response shimful instruction that disregards the lifetime
+///
+/// Fields are equivalent to the PrepareOrderResponseCctpShimAccounts struct
+struct PrepareOrderResponseShimAccountsHelper {
     pub signer: Pubkey,
     pub custodian: Pubkey,
     pub fast_market_order: Pubkey,
@@ -50,17 +297,32 @@ pub struct PrepareOrderResponseShimAccountsFixture {
     pub cctp_token_messenger_minter_event_authority: Pubkey,
     pub guardian_set: Pubkey,
     pub guardian_set_signatures: Pubkey,
+    pub prepared_order_response: Pubkey,
+    pub prepared_custody_token: Pubkey,
 }
 
-impl PrepareOrderResponseShimAccountsFixture {
+impl PrepareOrderResponseShimAccountsHelper {
+    /// Create a new prepare order response shim accounts helper
+    ///
+    /// # Arguments
+    ///
+    /// * `testing_context` - The testing context
+    /// * `config` - The prepare order response instruction config
+    /// * `current_state` - The current state
+    /// * `cctp_message_decoded` - The CCTP message decoded
+    /// * `data` - The prepare order response shim data helper
     pub fn new(
         testing_context: &TestingContext,
         config: &PrepareOrderResponseInstructionConfig,
         current_state: &TestingEngineState,
-        signer: &Pubkey,
         cctp_message_decoded: &CctpMessageDecoded,
-        guardian_signature_info: &GuardianSignatureInfo,
+        data: &PrepareOrderResponseShimDataHelper,
     ) -> Self {
+        let guardian_signature_info = &data.guardian_signature_info;
+        let signer = &config
+            .payer_signer
+            .clone()
+            .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
         let usdc_mint_address = testing_context.get_usdc_mint_address();
         let auction_accounts = config
             .overwrite_auction_accounts
@@ -117,8 +379,27 @@ impl PrepareOrderResponseShimAccountsFixture {
             }
             _ => panic!("Unsupported transfer direction"),
         };
+        let matching_engine_program_id = &testing_context.get_matching_engine_program_id();
+        let fast_market_order_digest = data.fast_market_order.digest();
+        let prepared_order_response_seeds = [
+            PreparedOrderResponse::SEED_PREFIX,
+            &fast_market_order_digest,
+        ];
+
+        let (prepared_order_response_pda, _prepared_order_response_bump) =
+            Pubkey::find_program_address(
+                &prepared_order_response_seeds,
+                matching_engine_program_id,
+            );
+
+        let prepared_custody_token_seeds = [
+            matching_engine::PREPARED_CUSTODY_TOKEN_SEED_PREFIX,
+            prepared_order_response_pda.as_ref(),
+        ];
+        let (prepared_custody_token_pda, _prepared_custody_token_bump) =
+            Pubkey::find_program_address(&prepared_custody_token_seeds, matching_engine_program_id);
         Self {
-            signer: *signer,
+            signer: signer.pubkey(),
             custodian,
             fast_market_order,
             from_endpoint,
@@ -141,282 +422,8 @@ impl PrepareOrderResponseShimAccountsFixture {
             cctp_token_messenger_minter_event_authority: token_messenger_minter_event_authority,
             guardian_set: guardian_signature_info.guardian_set_pubkey,
             guardian_set_signatures: guardian_signature_info.guardian_signatures_pubkey,
-        }
-    }
-}
-
-/// Prepare order response shim data helper
-///
-/// This struct is a helper struct used to create the data for the prepare order response instruction
-///
-/// # Fields
-///
-/// * `encoded_cctp_message` - The encoded CCTP message
-/// * `cctp_attestation` - The CCTP attestation
-/// * `finalized_vaa_message_args` - The finalized VAA message args
-/// * `fast_market_order` - The fast market order
-pub struct PrepareOrderResponseShimDataHelper {
-    pub encoded_cctp_message: Vec<u8>,
-    pub cctp_attestation: Vec<u8>,
-    pub finalized_vaa_message_args: FinalizedVaaMessageArgs,
-    pub fast_market_order: FastMarketOrderState,
-}
-
-impl PrepareOrderResponseShimDataHelper {
-    /// Create a new prepare order response shim data helper
-    ///
-    /// # Arguments
-    ///
-    /// * `encoded_cctp_message` - The encoded CCTP message
-    /// * `cctp_attestation` - The CCTP attestation
-    /// * `consistency_level` - The consistency level
-    /// * `base_fee` - The base fee
-    /// * `fast_market_order` - The fast market order
-    /// * `guardian_set_bump` - The guardian set bump
-    ///
-    /// # Returns
-    ///
-    /// The prepare order response shim data helper
-    pub fn new(
-        encoded_cctp_message: Vec<u8>,
-        cctp_attestation: Vec<u8>,
-        consistency_level: u8,
-        base_fee: u64,
-        fast_market_order: &FastMarketOrderState,
-        guardian_set_bump: u8,
-    ) -> Self {
-        Self {
-            encoded_cctp_message,
-            cctp_attestation,
-            finalized_vaa_message_args: FinalizedVaaMessageArgs {
-                consistency_level,
-                base_fee,
-                guardian_set_bump,
-            },
-            fast_market_order: *fast_market_order,
-        }
-    }
-    pub fn decode_cctp_message(&self) -> CctpMessageDecoded {
-        let cctp_message_decoded = CctpMessage::parse(&self.encoded_cctp_message[..]).unwrap();
-        CctpMessageDecoded {
-            nonce: cctp_message_decoded.nonce(),
-            source_domain: cctp_message_decoded.source_domain(),
-        }
-    }
-}
-
-/// Executes the instruction that prepares the order response for the CCTP shim
-///
-/// # Arguments
-///
-/// * `testing_context` - The testing context
-/// * `test_context` - The test context
-/// * `payer_signer` - The payer signer
-/// * `accounts` - The prepare order response shim accounts
-/// * `data` - The prepare order response shim data
-/// * `expected_error` - The expected error
-///
-/// # Returns
-///
-/// The prepare order response shim fixture
-pub async fn prepare_order_response_cctp_shim(
-    testing_context: &TestingContext,
-    test_context: &mut ProgramTestContext,
-    payer_signer: &Rc<Keypair>,
-    accounts: PrepareOrderResponseShimAccountsFixture,
-    data: PrepareOrderResponseShimDataHelper,
-    expected_error: Option<&ExpectedError>,
-) -> Option<PrepareOrderResponseShimFixture> {
-    let matching_engine_program_id = &testing_context.get_matching_engine_program_id();
-    let fast_market_order_digest = data.fast_market_order.digest();
-    let prepared_order_response_seeds = [
-        PreparedOrderResponse::SEED_PREFIX,
-        &fast_market_order_digest,
-    ];
-
-    let (prepared_order_response_pda, _prepared_order_response_bump) =
-        Pubkey::find_program_address(&prepared_order_response_seeds, matching_engine_program_id);
-
-    let prepared_custody_token_seeds = [
-        matching_engine::PREPARED_CUSTODY_TOKEN_SEED_PREFIX,
-        prepared_order_response_pda.as_ref(),
-    ];
-    let (prepared_custody_token_pda, _prepared_custody_token_bump) =
-        Pubkey::find_program_address(&prepared_custody_token_seeds, matching_engine_program_id);
-
-    let ix_accounts = PrepareOrderResponseCctpShimAccounts {
-        signer: &accounts.signer,
-        custodian: &accounts.custodian,
-        fast_market_order: &accounts.fast_market_order,
-        from_endpoint: &accounts.from_endpoint,
-        to_endpoint: &accounts.to_endpoint,
-        prepared_order_response: &prepared_order_response_pda,
-        prepared_custody_token: &prepared_custody_token_pda,
-        base_fee_token: &accounts.base_fee_token,
-        usdc: &accounts.usdc,
-        cctp_mint_recipient: &accounts.cctp_mint_recipient,
-        cctp_message_transmitter_authority: &accounts.cctp_message_transmitter_authority,
-        cctp_message_transmitter_config: &accounts.cctp_message_transmitter_config,
-        cctp_used_nonces: &accounts.cctp_used_nonces,
-        cctp_message_transmitter_event_authority: &accounts
-            .cctp_message_transmitter_event_authority,
-        cctp_token_messenger: &accounts.cctp_token_messenger,
-        cctp_remote_token_messenger: &accounts.cctp_remote_token_messenger,
-        cctp_token_minter: &accounts.cctp_token_minter,
-        cctp_local_token: &accounts.cctp_local_token,
-        cctp_token_pair: &accounts.cctp_token_pair,
-        cctp_token_messenger_minter_event_authority: &accounts
-            .cctp_token_messenger_minter_event_authority,
-        cctp_token_messenger_minter_custody_token: &accounts
-            .cctp_token_messenger_minter_custody_token,
-        cctp_token_messenger_minter_program: &accounts.cctp_token_messenger_minter_program,
-        cctp_message_transmitter_program: &accounts.cctp_message_transmitter_program,
-        guardian_set: &accounts.guardian_set,
-        guardian_set_signatures: &accounts.guardian_set_signatures,
-        verify_shim_program: &wormhole_svm_definitions::solana::VERIFY_VAA_SHIM_PROGRAM_ID,
-        token_program: &spl_token::ID,
-        system_program: &solana_program::system_program::ID,
-    };
-
-    let finalized_vaa_message_args = data.finalized_vaa_message_args;
-    let data = PrepareOrderResponseCctpShimData {
-        encoded_cctp_message: data.encoded_cctp_message,
-        cctp_attestation: data.cctp_attestation,
-        finalized_vaa_message_args,
-    };
-
-    let prepare_order_response_cctp_shim_ix = PrepareOrderResponseCctpShimIx {
-        program_id: matching_engine_program_id,
-        accounts: ix_accounts,
-        data,
-    }
-    .instruction();
-
-    let recent_blockhash = testing_context
-        .get_new_latest_blockhash(test_context)
-        .await
-        .expect("Failed to get new latest blockhash");
-    let transaction = Transaction::new_signed_with_payer(
-        &[prepare_order_response_cctp_shim_ix],
-        Some(&payer_signer.pubkey()),
-        &[&payer_signer],
-        recent_blockhash,
-    );
-    testing_context
-        .execute_and_verify_transaction(test_context, transaction, expected_error)
-        .await;
-    if expected_error.is_none() {
-        Some(PrepareOrderResponseShimFixture {
             prepared_order_response: prepared_order_response_pda,
             prepared_custody_token: prepared_custody_token_pda,
-            base_fee_token: accounts.base_fee_token,
-        })
-    } else {
-        None
+        }
     }
-}
-
-/// Prepare order response test
-///
-/// Executes the prepare order response instruction in a testing context
-///
-/// # Arguments
-///
-/// * `testing_context` - The testing context
-/// * `test_context` - The test context
-/// * `config` - The prepare order response instruction config
-/// * `current_state` - The current state
-///
-/// # Returns
-///
-/// The prepare order response shim fixture (none if failed)
-pub async fn prepare_order_response_test(
-    testing_context: &TestingContext,
-    test_context: &mut ProgramTestContext,
-    config: &PrepareOrderResponseInstructionConfig,
-    current_state: &TestingEngineState,
-) -> Option<PrepareOrderResponseShimFixture> {
-    let payer_signer = config
-        .payer_signer
-        .clone()
-        .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
-    let deposit_vaa = current_state
-        .get_test_vaa_pair(config.vaa_index)
-        .deposit_vaa
-        .clone();
-    let deposit_vaa_data = deposit_vaa.get_vaa_data();
-    let deposit = deposit_vaa
-        .payload_deserialized
-        .clone()
-        .unwrap()
-        .get_deposit()
-        .unwrap();
-    let core_bridge_program_id = &testing_context.get_wormhole_program_id();
-
-    let finalized_vaa_data = current_state
-        .get_test_vaa_pair(config.vaa_index)
-        .get_finalized_vaa_data()
-        .clone();
-
-    let guardian_signature_info = super::verify_shim::create_guardian_signatures(
-        testing_context,
-        test_context,
-        &payer_signer,
-        &finalized_vaa_data,
-        core_bridge_program_id,
-        None,
-    )
-    .await
-    .unwrap();
-
-    let fast_market_order_state = current_state
-        .fast_market_order()
-        .expect("could not find fast market order")
-        .fast_market_order;
-
-    let cctp_token_burn_message = utils::cctp_message::craft_cctp_token_burn_message(
-        testing_context,
-        test_context,
-        current_state,
-        config.vaa_index,
-    )
-    .await
-    .unwrap();
-    cctp_token_burn_message
-        .verify_cctp_message(&fast_market_order_state)
-        .unwrap();
-
-    let deposit_base_fee = utils::cctp_message::get_deposit_base_fee(&deposit);
-    let prepare_order_response_cctp_shim_data = PrepareOrderResponseShimDataHelper::new(
-        cctp_token_burn_message.encoded_cctp_burn_message,
-        cctp_token_burn_message.cctp_attestation,
-        deposit_vaa_data.consistency_level,
-        deposit_base_fee,
-        &fast_market_order_state,
-        guardian_signature_info.guardian_set_bump,
-    );
-    let cctp_message_decoded = prepare_order_response_cctp_shim_data.decode_cctp_message();
-    let prepare_order_response_cctp_shim_accounts = PrepareOrderResponseShimAccountsFixture::new(
-        testing_context,
-        config,
-        current_state,
-        &payer_signer.pubkey(),
-        &cctp_message_decoded,
-        &guardian_signature_info,
-    );
-    super::shims_prepare_order_response::prepare_order_response_cctp_shim(
-        testing_context,
-        test_context,
-        &payer_signer,
-        prepare_order_response_cctp_shim_accounts,
-        prepare_order_response_cctp_shim_data,
-        config.expected_error(),
-    )
-    .await
-}
-
-pub struct PrepareOrderResponseShimFixture {
-    pub prepared_order_response: Pubkey,
-    pub prepared_custody_token: Pubkey,
-    pub base_fee_token: Pubkey,
 }

--- a/solana/modules/matching-engine-testing/tests/shimful/verify_shim.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/verify_shim.rs
@@ -18,6 +18,13 @@ use std::str::FromStr;
 use wormhole_svm_definitions::GUARDIAN_SIGNATURE_LENGTH;
 use wormhole_svm_shim::verify_vaa;
 
+/// Guardian signature info
+///
+/// # Fields
+///
+/// * `guardian_set_pubkey` - The guardian set pubkey
+/// * `guardian_signatures_pubkey` - The guardian signatures pubkey
+/// * `guardian_set_bump` - The guardian set bump
 pub struct GuardianSignatureInfo {
     pub guardian_set_pubkey: Pubkey,
     pub guardian_signatures_pubkey: Pubkey,

--- a/solana/modules/matching-engine-testing/tests/shimless/initialize.rs
+++ b/solana/modules/matching-engine-testing/tests/shimless/initialize.rs
@@ -181,7 +181,7 @@ pub async fn initialize_program(
             test_context,
             &[instruction],
             Some(&payer_signer.pubkey()),
-            &[&payer_signer],
+            &[&payer_signer, &testing_context.testing_actors.owner.keypair()],
             1000000000,
             1000000000,
         )
@@ -200,7 +200,7 @@ pub async fn initialize_program(
                 test_context,
                 &[instruction],
                 Some(&payer_signer.pubkey()),
-                &[&payer_signer,],
+                &[&payer_signer, &testing_context.testing_actors.owner.keypair()],
                 1000000000,
                 1000000000,
             )

--- a/solana/modules/matching-engine-testing/tests/shimless/initialize.rs
+++ b/solana/modules/matching-engine-testing/tests/shimless/initialize.rs
@@ -181,9 +181,12 @@ pub async fn initialize_program(
             test_context,
             &[instruction],
             Some(&payer_signer.pubkey()),
-            &[&payer_signer, &testing_context.testing_actors.owner.keypair()],
-            1000000000,
-            1000000000,
+            &[
+                &payer_signer,
+                &testing_context.testing_actors.owner.keypair(),
+            ],
+            None,
+            None,
         )
         .await;
     // Process transaction
@@ -200,9 +203,12 @@ pub async fn initialize_program(
                 test_context,
                 &[instruction],
                 Some(&payer_signer.pubkey()),
-                &[&payer_signer, &testing_context.testing_actors.owner.keypair()],
-                1000000000,
-                1000000000,
+                &[
+                    &payer_signer,
+                    &testing_context.testing_actors.owner.keypair(),
+                ],
+                None,
+                None,
             )
             .await;
         let versioned_transaction = VersionedTransaction::from(transaction);

--- a/solana/modules/matching-engine-testing/tests/shimless/settle_auction.rs
+++ b/solana/modules/matching-engine-testing/tests/shimless/settle_auction.rs
@@ -39,7 +39,7 @@ pub async fn settle_auction_complete(
     test_context: &mut ProgramTestContext,
     config: &SettleAuctionInstructionConfig,
     expected_error: Option<&ExpectedError>,
-) -> AuctionState {
+) -> TestingEngineState {
     let payer_signer = &config
         .payer_signer
         .clone()
@@ -102,8 +102,17 @@ pub async fn settle_auction_complete(
         .execute_and_verify_transaction(test_context, tx, expected_error)
         .await;
     if expected_error.is_none() {
-        AuctionState::Settled
+        TestingEngineState::AuctionSettled {
+            base: current_state.base().clone(),
+            initialized: current_state.initialized().unwrap().clone(),
+            router_endpoints: current_state.router_endpoints().unwrap().clone(),
+            auction_state: AuctionState::Settled(Box::new(active_auction.clone())),
+            fast_market_order: current_state.fast_market_order().cloned(),
+            order_prepared: current_state.order_prepared().unwrap().clone(),
+            auction_accounts: current_state.auction_accounts().cloned(),
+            order_executed: current_state.order_executed().cloned(),
+        }
     } else {
-        AuctionState::Active(Box::new(active_auction.clone()))
+        current_state.clone()
     }
 }

--- a/solana/modules/matching-engine-testing/tests/test_scenarios/execute_order.rs
+++ b/solana/modules/matching-engine-testing/tests/test_scenarios/execute_order.rs
@@ -970,7 +970,7 @@ pub async fn test_execute_order_shim_after_close_fast_market_order_fails() {
         )
         .await;
     let expected_error = ExpectedError {
-        instruction_index: 0,
+        instruction_index: 2,
         error_code: 3001, // Account Discriminator not found
         error_string: "AccountDiscriminatorNotFound.".to_string(),
     };
@@ -1081,7 +1081,7 @@ pub async fn test_execute_order_shim_emitter_chain_mismatch() {
         ExecuteOrderInstructionConfig {
             vaa_index: 1,
             expected_error: Some(ExpectedError {
-                instruction_index: 0,
+                instruction_index: 2,
                 error_code: u32::from(MatchingEngineError::VaaMismatch),
                 error_string: "AccountNotInitialized".to_string(),
             }),
@@ -1112,7 +1112,7 @@ pub async fn test_execute_order_shim_before_auction_duration_is_over() {
         ExecuteOrderInstructionConfig {
             fast_forward_slots: 0,
             expected_error: Some(ExpectedError {
-                instruction_index: 0,
+                instruction_index: 2,
                 error_code: u32::from(MatchingEngineError::AuctionPeriodNotExpired),
                 error_string: "AuctionPeriodNotExpired".to_string(),
             }),

--- a/solana/modules/matching-engine-testing/tests/test_scenarios/initialize_and_misc.rs
+++ b/solana/modules/matching-engine-testing/tests/test_scenarios/initialize_and_misc.rs
@@ -131,7 +131,7 @@ pub async fn test_local_token_router_endpoint_creation() {
         &config,
     )
     .await;
-    let custodian = initialize_state.auction_accounts().unwrap().custodian;
+    let custodian = initialize_state.initialized().unwrap().custodian_address;
     let owner = &testing_engine.testing_context.testing_actors.owner;
     let _local_token_router_endpoint = add_local_router_endpoint_ix(
         &testing_engine.testing_context,

--- a/solana/modules/matching-engine-testing/tests/testing_engine/config.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/config.rs
@@ -619,3 +619,36 @@ pub struct BalanceChange {
     pub usdc: i32,
     pub usdt: i32,
 }
+
+pub struct CombinedInstructionConfig {
+    pub create_fast_market_order_config: Option<InitializeFastMarketOrderShimInstructionConfig>,
+    pub place_initial_offer_config: Option<PlaceInitialOfferInstructionConfig>,
+    pub execute_order_config: Option<ExecuteOrderInstructionConfig>,
+    pub settle_auction_config: Option<SettleAuctionInstructionConfig>,
+    pub close_fast_market_order_config: Option<CloseFastMarketOrderShimInstructionConfig>,
+    pub improve_offer_config: Option<ImproveOfferInstructionConfig>,
+}
+
+impl Default for CombinedInstructionConfig {
+    fn default() -> Self {
+        Self {
+            create_fast_market_order_config: None,
+            place_initial_offer_config: None,
+            execute_order_config: None,
+            settle_auction_config: None,
+            close_fast_market_order_config: None,
+            improve_offer_config: None,
+        }
+    }
+}
+
+impl CombinedInstructionConfig {
+   pub fn create_fast_market_order_and_place_initial_offer(
+    ) -> Self {
+        Self {
+            create_fast_market_order_config: Some(InitializeFastMarketOrderShimInstructionConfig::default()),
+            place_initial_offer_config: Some(PlaceInitialOfferInstructionConfig::default()),
+            ..Default::default()
+        }
+    }
+}

--- a/solana/modules/matching-engine-testing/tests/testing_engine/config.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/config.rs
@@ -52,7 +52,7 @@ pub type OverwriteCurrentState<T> = Option<T>;
 ///
 /// # Fields
 ///
-/// * `instruction_index` - The index of the instruction that is expected to error
+/// * `instruction_index` - The index of the instruction that is expected to error. Because of how the transaction is built in the testing engine, the instruction index is always at least 2.
 /// * `error_code` - The error code that is expected to be returned
 /// * `error_string` - A description of the error that is expected to be returned for debugging purposes
 // TODO: Change the error string to either be checked for or change the field name AND make it optional

--- a/solana/modules/matching-engine-testing/tests/testing_engine/engine.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/engine.rs
@@ -724,6 +724,7 @@ impl TestingEngine {
         current_state.clone()
     }
 
+    /// Verify the balances after an instruction has been executed. Currently only used for execute order instruction
     async fn verify_balances(
         &self,
         test_context: &mut ProgramTestContext,
@@ -773,6 +774,7 @@ impl TestingEngine {
     // Combination trigger functions
     // --------------------------------------------------------------------------------------------
 
+    /// A transaction that combines the instructions for creating a fast market order and placing an initial offer
     async fn create_fast_market_order_and_place_initial_offer(
         &self,
         test_context: &mut ProgramTestContext,

--- a/solana/modules/matching-engine-testing/tests/testing_engine/engine.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/engine.rs
@@ -391,6 +391,10 @@ impl TestingEngine {
         }
     }
 
+    // --------------------------------------------------------------------------------------------
+    // Instruction trigger functions
+    // --------------------------------------------------------------------------------------------
+
     /// Creates the initial state for the testing engine
     pub fn create_initial_state(&self) -> TestingEngineState {
         let fixture_accounts = self
@@ -536,6 +540,8 @@ impl TestingEngine {
             order_executed: current_state.order_executed().cloned(),
         }
     }
+
+    /// Instruction trigger function for placing an initial offer
     async fn place_initial_offer_shimless(
         &self,
         test_context: &mut ProgramTestContext,
@@ -860,6 +866,10 @@ impl TestingEngine {
         }
     }
 
+    // --------------------------------------------------------------------------------------------
+    // Verification trigger functions
+    // --------------------------------------------------------------------------------------------
+
     async fn verify_auction_state(
         &self,
         test_context: &mut ProgramTestContext,
@@ -922,6 +932,10 @@ impl TestingEngine {
         }
         current_state.clone()
     }
+
+    // --------------------------------------------------------------------------------------------
+    // Combination trigger functions
+    // --------------------------------------------------------------------------------------------
 
     async fn create_fast_market_order_and_place_initial_offer(
         &self,
@@ -1037,6 +1051,10 @@ impl TestingEngine {
         )
         .await
     }
+
+    // --------------------------------------------------------------------------------------------
+    // Helper functions for manipulating the state
+    // --------------------------------------------------------------------------------------------
 
     pub async fn make_auction_passed_penalty_period(
         &self,

--- a/solana/modules/matching-engine-testing/tests/testing_engine/engine.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/engine.rs
@@ -944,7 +944,6 @@ impl TestingEngine {
             .payer_signer
             .clone()
             .unwrap_or_else(|| self.testing_context.testing_actors.payer_signer.clone());
-        println!("Got here 0");
         let guardian_signature_info = create_guardian_signatures(
             &self.testing_context,
             test_context,
@@ -981,7 +980,6 @@ impl TestingEngine {
             .payer_signer
             .clone()
             .unwrap_or_else(|| self.testing_context.testing_actors.payer_signer.clone());
-        println!("Got here 1");
         let transaction = self
             .testing_context
             .create_transaction(
@@ -998,7 +996,6 @@ impl TestingEngine {
                 1000000000,
             )
             .await;
-        println!("Got here 2");
         let actor_usdc_balance_before = place_initial_offer_config
             .actor
             .get_actor(&self.testing_context.testing_actors)
@@ -1012,7 +1009,6 @@ impl TestingEngine {
         self.testing_context
             .execute_and_verify_transaction(test_context, transaction, None)
             .await;
-        println!("Got here 3");
         let fast_market_order_created_state = TestingEngineState::FastMarketOrderAccountCreated {
             base: current_state.base().clone(),
             initialized: current_state.initialized().unwrap().clone(),

--- a/solana/modules/matching-engine-testing/tests/testing_engine/setup.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/setup.rs
@@ -378,6 +378,20 @@ impl TestingContext {
         Ok(())
     }
 
+    /// Creates a transaction
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    /// * `instructions` - The instructions to include in the transaction
+    /// * `payer` - The payer of the transaction
+    /// * `signers` - The signers of the transaction
+    /// * `compute_unit_price` - The compute unit price of the transaction
+    /// * `compute_unit_limit` - The compute unit limit of the transaction
+    ///
+    /// # Returns
+    ///
+    /// The transaction
     pub async fn create_transaction(
         &self,
         test_context: &mut ProgramTestContext,
@@ -399,7 +413,13 @@ impl TestingContext {
         Transaction::new_signed_with_payer(&all_instructions, payer, signers, last_blockhash)
     }
 
-    // TODO: Edit to handle multiple instructions in a single transaction
+    /// Executes a transaction and verifies that the transaction either succeeds or fails as expected
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    /// * `transaction` - The transaction to execute
+    /// * `expected_error` - The expected error
     pub async fn execute_and_verify_transaction(
         &self,
         test_context: &mut ProgramTestContext,
@@ -457,10 +477,27 @@ impl TestingContext {
     }
 
     /// Gets the balances of all the test actors
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    ///
+    /// # Returns
+    ///
+    /// The balances of all the test actors
     pub async fn get_balances(&self, test_context: &mut ProgramTestContext) -> Balances {
         Balances::new(&self.testing_actors, test_context).await
     }
 
+    /// Gets the current timestamp
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    ///
+    /// # Returns
+    ///
+    /// The current timestamp as an i64
     pub async fn get_current_timestamp(&self, test_context: &mut ProgramTestContext) -> i64 {
         let clock = test_context
             .banks_client
@@ -470,6 +507,12 @@ impl TestingContext {
         clock.unix_timestamp
     }
 
+    /// Fast forwards the clock to the given timestamp
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    /// * `target_timestamp` - The timestamp to fast forward to
     pub async fn fast_forward_to_timestamp(
         &self,
         test_context: &mut ProgramTestContext,
@@ -484,6 +527,12 @@ impl TestingContext {
         assert!(current_timestamp >= target_timestamp);
     }
 
+    /// Makes the fast transfer VAA expired
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    /// * `seconds_after_expiry` - The number of seconds after the VAA expiration time to make the VAA expired
     pub async fn make_fast_transfer_vaa_expired(
         &self,
         test_context: &mut ProgramTestContext,
@@ -499,6 +548,15 @@ impl TestingContext {
             .await;
     }
 
+    /// Gets the remote token messenger
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    ///
+    /// # Returns
+    ///
+    /// The remote token messenger as a CctpRemoteTokenMessenger
     pub async fn get_remote_token_messenger(
         &self,
         test_context: &mut ProgramTestContext,
@@ -549,14 +607,29 @@ impl Solver {
         }
     }
 
+    /// Gets the keypair
+    ///
+    /// # Returns
+    ///
+    /// The keypair as an Rc<Keypair>
     pub fn keypair(&self) -> Rc<Keypair> {
         self.actor.keypair.clone()
     }
 
+    /// Gets the pubkey
+    ///
+    /// # Returns
+    ///
+    /// The pubkey as a Pubkey
     pub fn pubkey(&self) -> Pubkey {
         self.actor.keypair.pubkey()
     }
 
+    /// Gets the token account address
+    ///
+    /// # Returns
+    ///
+    /// The token account address as an Option<Pubkey>
     pub fn token_account_address(&self) -> Option<Pubkey> {
         self.actor.usdc_token_account.as_ref().map(|t| t.address)
     }
@@ -580,6 +653,16 @@ impl Solver {
             .await;
     }
 
+    /// Gets the balance of the token account
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    /// * `spl_token_enum` - The SPL token enum
+    ///
+    /// # Returns
+    ///
+    /// The balance of the token account as a u64
     pub async fn get_token_account_balance(
         &self,
         test_context: &mut ProgramTestContext,
@@ -590,6 +673,15 @@ impl Solver {
             .await
     }
 
+    /// Gets the balance of the actor's lamports
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    ///
+    /// # Returns
+    ///
+    /// The balance of the actor's lamports as a u64
     pub async fn get_lamport_balance(&self, test_context: &mut ProgramTestContext) -> u64 {
         self.actor.get_lamport_balance(test_context).await
     }
@@ -631,13 +723,34 @@ impl TestingActor {
             usdt_token_account,
         }
     }
+
+    /// Gets the pubkey
+    ///
+    /// # Returns
+    ///
+    /// The pubkey as a Pubkey
     pub fn pubkey(&self) -> Pubkey {
         self.keypair.pubkey()
     }
+
+    /// Gets the keypair
+    ///
+    /// # Returns
+    ///
+    /// The keypair as an Rc<Keypair>
     pub fn keypair(&self) -> Rc<Keypair> {
         self.keypair.clone()
     }
 
+    /// Gets the token account address
+    ///
+    /// # Arguments
+    ///
+    /// * `spl_token_enum` - The SPL token enum
+    ///
+    /// # Returns
+    ///
+    /// The token account address if it exists, otherwise None
     pub fn token_account_address(&self, spl_token_enum: &SplTokenEnum) -> Option<Pubkey> {
         match spl_token_enum {
             SplTokenEnum::Usdc => self.usdc_token_account.as_ref().map(|t| t.address),
@@ -650,6 +763,11 @@ impl TestingActor {
     /// # Arguments
     ///
     /// * `test_context` - The test context
+    /// * `spl_token_enum` - The SPL token enum
+    ///
+    /// # Returns
+    ///
+    /// The balance of the token account as a u64
     pub async fn get_token_account_balance(
         &self,
         test_context: &mut ProgramTestContext,
@@ -672,6 +790,15 @@ impl TestingActor {
         }
     }
 
+    /// Gets the balance of the actor's lamports
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    ///
+    /// # Returns
+    ///
+    /// The balance of the actor's lamports as a u64
     pub async fn get_lamport_balance(&self, test_context: &mut ProgramTestContext) -> u64 {
         test_context
             .banks_client
@@ -721,6 +848,12 @@ impl TestingActor {
             .expect("Failed to approve USDC");
     }
 
+    /// Closes a token account
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    /// * `spl_token_enum` - The SPL token enum
     pub async fn close_token_account(
         &self,
         test_context: &mut ProgramTestContext,
@@ -937,7 +1070,11 @@ impl TestingActors {
         actors
     }
 
-    /// Transfer Lamports to Executors
+    /// Transfers 10000000000 Lamports to all the actors
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
     async fn airdrop_all(&self, test_context: &mut ProgramTestContext) {
         airdrop(test_context, &self.payer_signer.pubkey(), 10000000000).await;
         airdrop(test_context, &self.owner.pubkey(), 10000000000).await;
@@ -950,7 +1087,14 @@ impl TestingActors {
         airdrop(test_context, &self.liquidator.pubkey(), 10000000000).await;
     }
 
-    /// Set up ATAs for Various Owners
+    /// Creates USDC associated token accounts
+    /// 
+    /// Creates usdc associated token accounts for all actors that expect to have them
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    /// * `usdc_mint_address` - The USDC mint address
     async fn create_usdc_atas(
         &mut self,
         test_context: &mut ProgramTestContext,
@@ -970,7 +1114,14 @@ impl TestingActors {
         }
     }
 
-    /// Create usdt associated token accounts
+    /// Creates USDT associated token accounts
+    ///
+    /// Creates usdt associated token accounts for all actors that expect to have them
+    ///
+    /// # Arguments
+    ///
+    /// * `test_context` - The test context
+    /// * `usdt_mint_address` - The USDT mint address
     pub async fn create_usdt_atas(
         &mut self,
         test_context: &mut ProgramTestContext,
@@ -990,6 +1141,11 @@ impl TestingActors {
         }
     }
 
+    /// Gets an actor
+    ///
+    /// # Arguments
+    ///
+    /// * `actor_enum` - The actor enum
     pub fn get_actor(&self, actor_enum: &TestingActorEnum) -> &TestingActor {
         match actor_enum {
             TestingActorEnum::Owner => &self.owner,
@@ -1001,7 +1157,7 @@ impl TestingActors {
         }
     }
 
-    /// Add solvers to the testing actors
+    /// Add solvers to the testing actors struct
     #[allow(dead_code)]
     pub async fn add_solvers(
         &mut self,

--- a/solana/modules/matching-engine-testing/tests/testing_engine/setup.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/setup.rs
@@ -157,6 +157,8 @@ impl PreTestingContext {
     }
 }
 
+// TODO: Move the testing context to a different module
+
 /// Testing Context struct that stores common data needed to run tests
 ///
 /// # Fields
@@ -398,9 +400,11 @@ impl TestingContext {
         instructions: &[Instruction],
         payer: Option<&Pubkey>,
         signers: &[&Keypair],
-        compute_unit_price: u64,
-        compute_unit_limit: u32,
+        compute_unit_price: Option<u64>,
+        compute_unit_limit: Option<u32>,
     ) -> Transaction {
+        let compute_unit_price = compute_unit_price.unwrap_or_else(|| 1000000000);
+        let compute_unit_limit = compute_unit_limit.unwrap_or_else(|| 1000000000);
         let last_blockhash = self.get_new_latest_blockhash(test_context).await.unwrap();
         let compute_budget_price =
             ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price);
@@ -442,7 +446,7 @@ impl TestingContext {
                         instruction_index, expected_error.instruction_index,
                         "Expected error on instruction {}, but got: {:?}",
                         expected_error.instruction_index, tx_error
-                        );
+                    );
                     match instruction_error {
                         InstructionError::Custom(error_code) => {
                             assert_eq!(
@@ -1088,7 +1092,7 @@ impl TestingActors {
     }
 
     /// Creates USDC associated token accounts
-    /// 
+    ///
     /// Creates usdc associated token accounts for all actors that expect to have them
     ///
     /// # Arguments

--- a/solana/modules/matching-engine-testing/tests/utils/auction.rs
+++ b/solana/modules/matching-engine-testing/tests/utils/auction.rs
@@ -421,7 +421,7 @@ impl ActiveAuctionState {
 ///
 /// # Fields
 ///
-/// * `participant` - The participant of the offer
+/// * `participant` - The participant of the offer (the signer of the transaction)
 /// * `offer_token` - The token of the offer
 /// * `offer_price` - The price of the offer
 #[derive(Clone, Default)]

--- a/solana/modules/matching-engine-testing/tests/utils/auction.rs
+++ b/solana/modules/matching-engine-testing/tests/utils/auction.rs
@@ -47,7 +47,7 @@ pub struct AuctionAccounts {
 pub enum AuctionState {
     Active(Box<ActiveAuctionState>),
     Paused(Box<ActiveAuctionState>),
-    Settled,
+    Settled(Box<ActiveAuctionState>),
     Inactive,
 }
 
@@ -57,7 +57,7 @@ impl AuctionState {
             AuctionState::Active(auction) => Some(auction),
             AuctionState::Paused(auction) => Some(auction),
             AuctionState::Inactive => None,
-            AuctionState::Settled => None,
+            AuctionState::Settled(auction) => Some(auction),
         }
     }
 


### PR DESCRIPTION
## Aim of PR

This PR is one out of a few that aims to tackle the following suggestions:
- [x] Add a test to include both initialise fast market order and place initial offer in the same instruction


## Changes

- Adds the ability to compose instructions `CreateFastMarketOrder` and `PlaceInitialOfferShim` into one transaction in the testing environment
- Adds a test to test this composability works  – passes ✅ 
- Edits old docstrings that were out of date and adds new docstrings where there weren't any

