### PR TITLE
Reusing functions for audit [Bullet point 6]

### DIFF
--- a/solana/programs/matching-engine/src/processor/auction/execute_fast_order/mod.rs
+++ b/solana/programs/matching-engine/src/processor/auction/execute_fast_order/mod.rs
@@ -3,16 +3,17 @@ pub use cctp::*;
 
 mod local;
 pub use local::*;
+use solana_program::program::invoke_signed_unchecked;
 
 use crate::{
     composite::*,
     error::MatchingEngineError,
     events::OrderExecuted,
-    state::{Auction, AuctionStatus, MessageProtocol},
+    state::{Auction, AuctionConfig, AuctionInfo, AuctionStatus, MessageProtocol},
     utils::{self, auction::DepositPenalty},
 };
 use anchor_lang::prelude::*;
-use anchor_spl::token;
+use anchor_spl::token::{self, spl_token, TokenAccount};
 use common::messages::{
     raw::{LiquidityLayerMessage, MessageToVec},
     Fill,
@@ -42,186 +43,40 @@ fn handle_execute_fast_order<'info>(
         .unwrap()
         .to_fast_market_order_unchecked();
 
-    let (user_amount, new_status, order_executed_event) = {
-        let auction_info = auction.info.as_ref().unwrap();
-        let current_slot = Clock::get().unwrap().slot;
-
-        // We extend the grace period for locally executed orders. Reserving a sequence number for
-        // the fast fill will most likely require an additional transaction, so this buffer allows
-        // the best offer participant to perform his duty without the risk of getting slashed by
-        // another executor.
-        let additional_grace_period = match auction.target_protocol {
-            MessageProtocol::Local { .. } => {
-                crate::EXECUTE_FAST_ORDER_LOCAL_ADDITIONAL_GRACE_PERIOD.into()
-            }
-            _ => None,
-        };
-
-        let DepositPenalty {
-            penalty,
-            user_reward,
-        } = utils::auction::compute_deposit_penalty(
-            config,
-            auction_info,
-            current_slot,
-            additional_grace_period,
-        );
-
-        let init_auction_fee = order.init_auction_fee();
-
-        let user_amount = auction_info
-            .amount_in
-            .saturating_sub(auction_info.offer_price)
-            .saturating_sub(init_auction_fee)
-            .saturating_add(user_reward);
-
-        // Keep track of the remaining amount in the custody token account. Whatever remains will go
-        // to the executor.
-        let mut remaining_custodied_amount = custody_token.amount.saturating_sub(user_amount);
-
-        // Offer price + security deposit was checked in placing the initial offer.
-        let mut deposit_and_fee = auction_info
-            .offer_price
-            .saturating_add(auction_info.security_deposit)
-            .saturating_sub(user_reward);
-
-        let auction_signer_seeds = &[
-            Auction::SEED_PREFIX,
-            auction.vaa_hash.as_ref(),
-            &[auction.bump],
-        ];
-
-        let penalized = penalty > 0;
-
-        if penalized && best_offer_token.key() != executor_token.key() {
-            deposit_and_fee = deposit_and_fee.saturating_sub(penalty);
-        }
-
-        // If the initial offer token account doesn't exist anymore, we have nowhere to send the
-        // init auction fee. The executor will get these funds instead.
-        //
-        // We check that this is a legitimate token account.
-        if utils::checked_deserialize_token_account(initial_offer_token, &common::USDC_MINT)
-            .is_some()
-        {
-            if best_offer_token.key() != initial_offer_token.key() {
-                // Pay the auction initiator their fee.
-                token::transfer(
-                    CpiContext::new_with_signer(
-                        token_program.to_account_info(),
-                        token::Transfer {
-                            from: custody_token.to_account_info(),
-                            to: initial_offer_token.to_account_info(),
-                            authority: auction.to_account_info(),
-                        },
-                        &[auction_signer_seeds],
-                    ),
-                    init_auction_fee,
-                )?;
-
-                // Because the initial offer token was paid this fee, we account for it here.
-                remaining_custodied_amount =
-                    remaining_custodied_amount.saturating_sub(init_auction_fee);
-            } else {
-                // Add it to the reimbursement.
-                deposit_and_fee = deposit_and_fee
-                    .checked_add(init_auction_fee)
-                    .ok_or_else(|| MatchingEngineError::U64Overflow)?;
-            }
-        }
-
-        // Return the security deposit and the fee to the highest bidder.
-        //
-        if best_offer_token.key() == executor_token.key() {
-            // If the best offer token is equal to the executor token, just send whatever remains in
-            // the custody token account.
-            //
-            // NOTE: This will revert if the best offer token does not exist. But this will present
-            // an opportunity for another executor to execute this order and take what the best
-            // offer token would have received.
-            token::transfer(
-                CpiContext::new_with_signer(
-                    token_program.to_account_info(),
-                    token::Transfer {
-                        from: custody_token.to_account_info(),
-                        to: best_offer_token.to_account_info(),
-                        authority: auction.to_account_info(),
-                    },
-                    &[auction_signer_seeds],
-                ),
-                remaining_custodied_amount,
-            )?;
-        } else {
-            // Otherwise, send the deposit and fee to the best offer token. If the best offer token
-            // doesn't exist at this point (which would be unusual), we will reserve these funds
-            // for the executor token.
-            if utils::checked_deserialize_token_account(best_offer_token, &common::USDC_MINT)
-                .is_some()
-            {
-                token::transfer(
-                    CpiContext::new_with_signer(
-                        token_program.to_account_info(),
-                        token::Transfer {
-                            from: custody_token.to_account_info(),
-                            to: best_offer_token.to_account_info(),
-                            authority: auction.to_account_info(),
-                        },
-                        &[auction_signer_seeds],
-                    ),
-                    deposit_and_fee,
-                )?;
-
-                remaining_custodied_amount =
-                    remaining_custodied_amount.saturating_sub(deposit_and_fee);
-            }
-
-            // And pay the executor whatever remains in the auction custody token account.
-            if remaining_custodied_amount > 0 {
-                token::transfer(
-                    CpiContext::new_with_signer(
-                        token_program.to_account_info(),
-                        token::Transfer {
-                            from: custody_token.to_account_info(),
-                            to: executor_token.to_account_info(),
-                            authority: auction.to_account_info(),
-                        },
-                        &[auction_signer_seeds],
-                    ),
-                    remaining_custodied_amount,
-                )?;
-            }
-        }
-
-        // Set the authority of the custody token account to the custodian. He will take over from
-        // here.
-        token::set_authority(
-            CpiContext::new_with_signer(
-                token_program.to_account_info(),
-                token::SetAuthority {
-                    current_authority: auction.to_account_info(),
-                    account_or_mint: custody_token.to_account_info(),
-                },
-                &[auction_signer_seeds],
-            ),
-            token::spl_token::instruction::AuthorityType::AccountOwner,
-            custodian.key().into(),
-        )?;
-
-        (
-            user_amount,
-            AuctionStatus::Completed {
-                slot: current_slot,
-                execute_penalty: if penalized { penalty.into() } else { None },
-            },
-            OrderExecuted {
-                fast_vaa_hash: auction.vaa_hash,
-                vaa: fast_vaa.key(),
-                source_chain: auction_info.source_chain,
-                target_protocol: auction.target_protocol,
-                penalized,
-            },
-        )
+    let active_auction_account_infos = ActiveAuctionAccountInfos {
+        active_auction_best_offer_token: execute_order
+            .active_auction
+            .best_offer_token
+            .to_account_info(),
+        active_auction_executor_token: execute_order.executor_token.to_account_info(),
+        active_auction_initial_offer_token: execute_order.initial_offer_token.to_account_info(),
+        active_auction_custody_token: execute_order.active_auction.custody_token.to_account_info(),
+        active_auction: auction.to_account_info(),
+        active_auction_custodian: custodian.to_account_info(),
     };
+
+    let accounts = &[
+        auction.to_account_info(),
+        custody_token.to_account_info(),
+        config.to_account_info(),
+        executor_token.to_account_info(),
+        best_offer_token.to_account_info(),
+        initial_offer_token.to_account_info(),
+        fast_vaa.to_account_info(),
+        token_program.to_account_info(),
+    ];
+
+    let (user_amount, new_status, penalized) = get_user_amount_and_new_status_and_penalized(
+        auction,
+        custody_token,
+        config,
+        order.init_auction_fee(),
+        active_auction_account_infos,
+        accounts,
+    )?;
+
+    let order_executed_event =
+        get_order_executed_event(auction, fast_vaa, auction.info.as_ref().unwrap(), penalized);
 
     // Set the auction status to completed.
     auction.status = new_status;
@@ -239,4 +94,211 @@ fn handle_execute_fast_order<'info>(
         },
         order_executed_event,
     })
+}
+
+pub struct ActiveAuctionAccountInfos<'ix> {
+    pub active_auction_best_offer_token: AccountInfo<'ix>,
+    pub active_auction_executor_token: AccountInfo<'ix>,
+    pub active_auction_initial_offer_token: AccountInfo<'ix>,
+    pub active_auction_custody_token: AccountInfo<'ix>,
+    pub active_auction: AccountInfo<'ix>,
+    pub active_auction_custodian: AccountInfo<'ix>,
+}
+
+pub fn get_user_amount_and_new_status_and_penalized<'ix>(
+    auction: &Auction,
+    custody_token: &TokenAccount,
+    auction_config: &AuctionConfig,
+    init_auction_fee: u64,
+    active_auction_account_infos: ActiveAuctionAccountInfos<'ix>,
+    accounts: &[AccountInfo],
+) -> Result<(u64, AuctionStatus, bool)> {
+    let auction_info = auction.info.as_ref().unwrap();
+    let current_slot = Clock::get().unwrap().slot;
+
+    let ActiveAuctionAccountInfos {
+        active_auction_best_offer_token,
+        active_auction_executor_token,
+        active_auction_initial_offer_token,
+        active_auction_custody_token,
+        active_auction,
+        active_auction_custodian,
+    } = active_auction_account_infos;
+
+    let additional_grace_period = match auction.target_protocol {
+        MessageProtocol::Local { .. } => {
+            crate::EXECUTE_FAST_ORDER_LOCAL_ADDITIONAL_GRACE_PERIOD.into()
+        }
+        _ => None,
+    };
+
+    let DepositPenalty {
+        penalty,
+        user_reward,
+    } = utils::auction::compute_deposit_penalty(
+        &auction_config.parameters,
+        auction_info,
+        current_slot,
+        additional_grace_period,
+    );
+
+    let user_amount = auction_info
+        .amount_in
+        .saturating_sub(auction_info.offer_price)
+        .saturating_sub(init_auction_fee)
+        .saturating_add(user_reward);
+    let mut remaining_custodied_amount = custody_token.amount.saturating_sub(user_amount);
+
+    let mut deposit_and_fee = auction_info
+        .offer_price
+        .saturating_add(auction_info.security_deposit)
+        .saturating_sub(user_reward);
+
+    let auction_signer_seeds = &[
+        Auction::SEED_PREFIX,
+        auction.vaa_hash.as_ref(),
+        &[auction.bump],
+    ];
+
+    let penalized = penalty > 0;
+
+    if penalized && active_auction_best_offer_token.key() != active_auction_executor_token.key() {
+        deposit_and_fee = deposit_and_fee.saturating_sub(penalty);
+    }
+
+    if utils::checked_deserialize_token_account(
+        &active_auction_initial_offer_token,
+        &common::USDC_MINT,
+    )
+    .is_some()
+    {
+        if active_auction_best_offer_token.key() != active_auction_initial_offer_token.key() {
+            // Pay the auction initiator their fee.
+            let transfer_ix = spl_token::instruction::transfer(
+                &spl_token::ID,
+                &active_auction_custody_token.key(),
+                &active_auction_initial_offer_token.key(),
+                &active_auction.key(),
+                &[],
+                init_auction_fee,
+            )
+            .unwrap();
+
+            invoke_signed_unchecked(&transfer_ix, accounts, &[auction_signer_seeds])?;
+            // Because the initial offer token was paid this fee, we account for it here.
+            remaining_custodied_amount =
+                remaining_custodied_amount.saturating_sub(init_auction_fee);
+        } else {
+            // Add it to the reimbursement.
+            deposit_and_fee = deposit_and_fee
+                .checked_add(init_auction_fee)
+                .ok_or_else(|| MatchingEngineError::U64Overflow)?;
+        }
+    }
+
+    // Return the security deposit and the fee to the highest bidder.
+    if active_auction_best_offer_token.key() == active_auction_executor_token.key() {
+        // If the best offer token is equal to the executor token, just send whatever remains in
+        // the custody token account.
+        //
+        // NOTE: This will revert if the best offer token does not exist. But this will present
+        // an opportunity for another executor to execute this order and take what the best
+        // offer token would have received.
+        let transfer_ix = spl_token::instruction::transfer(
+            &spl_token::ID,
+            &active_auction_custody_token.key(),
+            &active_auction_best_offer_token.key(),
+            &active_auction.key(),
+            &[],
+            deposit_and_fee,
+        )
+        .unwrap();
+        msg!(
+            "Sending deposit and fee amount {} to best offer token account",
+            deposit_and_fee
+        );
+        invoke_signed_unchecked(&transfer_ix, accounts, &[auction_signer_seeds])?;
+    } else {
+        // Otherwise, send the deposit and fee to the best offer token. If the best offer token
+        // doesn't exist at this point (which would be unusual), we will reserve these funds
+        // for the executor token.
+        if utils::checked_deserialize_token_account(
+            &active_auction_best_offer_token,
+            &common::USDC_MINT,
+        )
+        .is_some()
+        {
+            let transfer_ix = spl_token::instruction::transfer(
+                &spl_token::ID,
+                &active_auction_custody_token.key(),
+                &active_auction_best_offer_token.key(),
+                &active_auction.key(),
+                &[],
+                deposit_and_fee,
+            )
+            .unwrap();
+            msg!(
+                "Sending deposit and fee {} to best offer token account",
+                deposit_and_fee
+            );
+            invoke_signed_unchecked(&transfer_ix, accounts, &[auction_signer_seeds])?;
+            remaining_custodied_amount = remaining_custodied_amount.saturating_sub(deposit_and_fee);
+        }
+
+        // And pay the executor whatever remains in the auction custody token account.
+        if remaining_custodied_amount > 0 {
+            let instruction = spl_token::instruction::transfer(
+                &spl_token::ID,
+                &active_auction_custody_token.key(),
+                &active_auction_executor_token.key(),
+                &active_auction.key(),
+                &[],
+                remaining_custodied_amount,
+            )
+            .unwrap();
+            msg!(
+                "Sending remaining custodied amount {} to executor token account",
+                remaining_custodied_amount
+            );
+            invoke_signed_unchecked(&instruction, accounts, &[auction_signer_seeds])?;
+        }
+    }
+
+    // Set the authority of the custody token account to the custodian. He will take over from
+    // here.
+    let set_authority_ix = spl_token::instruction::set_authority(
+        &spl_token::ID,
+        &active_auction_custody_token.key(),
+        Some(&active_auction_custodian.key()),
+        spl_token::instruction::AuthorityType::AccountOwner,
+        &active_auction.key(),
+        &[],
+    )
+    .unwrap();
+
+    invoke_signed_unchecked(&set_authority_ix, accounts, &[auction_signer_seeds])?;
+
+    Ok((
+        user_amount,
+        AuctionStatus::Completed {
+            slot: current_slot,
+            execute_penalty: if penalized { penalty.into() } else { None },
+        },
+        penalized,
+    ))
+}
+
+pub fn get_order_executed_event<'ix>(
+    auction: &Auction,
+    fast_vaa: &AccountInfo<'ix>,
+    auction_info: &AuctionInfo,
+    penalized: bool,
+) -> OrderExecuted {
+    OrderExecuted {
+        fast_vaa_hash: auction.vaa_hash,
+        vaa: fast_vaa.key(),
+        source_chain: auction_info.source_chain,
+        target_protocol: auction.target_protocol,
+        penalized,
+    }
 }


### PR DESCRIPTION
## Description

This pr aims to provide public helper functions in the shimless code (Anchor) that can be reused in the shimless implementation (Native rust).

## Purpose

Reusing code makes it easier to audit and leaves fewer vulnerabilities/headache in case of a change.

## Changes

This PR changes the logic in:

-  `programs/matching-engine/processor/auction/execute_fast_order/mod.rs` to use a more native rust style approach that can be reused in the `programs/matching-engine/fallback/processor/execute_order.rs`