### PR TITLE
Test that prepared order response and custody token are closed after settle_auction_none_cttp

### DIFF
--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -144,6 +144,7 @@ jobs:
       - name: make anchor-test-upgrade
         run: make anchor-test-upgrade
         working-directory: ./solana
+
   make-test-sbf:
     name: make test-sbf
     runs-on: ubuntu-latest
@@ -151,10 +152,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@master
+      - uses: metadaoproject/setup-anchor@v2
         with:
-          toolchain: ${{ env.RUSTC_VERSION }}
+          node-version: "20.11.0"
+          solana-cli-version: "1.18.15"
+          anchor-version: "0.30.1"
       - name: Git Submodule Update
         run: |
           git config --global user.email "actions@github.com"

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -144,3 +144,23 @@ jobs:
       - name: make anchor-test-upgrade
         run: make anchor-test-upgrade
         working-directory: ./solana
+  make-test-sbf:
+    name: make test-sbf
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUSTC_VERSION }}
+      - name: Git Submodule Update
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git submodule update --init --recursive
+        working-directory: ./solana
+      - name: make test-sbf
+        run: make test-sbf
+        working-directory: ./solana

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -75,7 +75,7 @@ test-sbf:
 	cargo build-sbf --features mainnet
 ### Unfortunately we cannot saturate all CPUs to perform tests due to nondeterministic `RpcError`
 ### reverts. We constrain the number of threads when we run these tests.
-	cd modules/matching-engine-testing && cargo test-sbf --features mainnet -- --test-threads 3
+	cd modules/matching-engine-testing && cargo test-sbf --features mainnet -- --test-threads 1
 
 .PHONY: anchor-test
 anchor-test: anchor-test-setup

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -75,7 +75,7 @@ test-sbf:
 	cargo build-sbf --features mainnet
 ### Unfortunately we cannot saturate all CPUs to perform tests due to nondeterministic `RpcError`
 ### reverts. We constrain the number of threads when we run these tests.
-	cd modules/matching-engine-testing && cargo test-sbf --features mainnet -- --test-threads 4
+	cd modules/matching-engine-testing && cargo test-sbf --features mainnet -- --test-threads 3
 
 .PHONY: anchor-test
 anchor-test: anchor-test-setup


### PR DESCRIPTION
## Description

Successfully tests:

- [x] Prepared order response is closed after `shims_settle_auction_none_cctp`
- [x] Prepared custody token is closed after `shims_settle_auction_none_cctp`