### PR TITLE
Shim/integration program todos/execute order

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -6971,7 +6971,6 @@ dependencies = [
 [[package]]
 name = "wormhole-svm-definitions"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole.git?rev=33dd6a56541c2d15d3e20faa1330ba542a5fa727#33dd6a56541c2d15d3e20faa1330ba542a5fa727"
 dependencies = [
  "borsh 1.5.0",
  "cfg-if",
@@ -6982,7 +6981,6 @@ dependencies = [
 [[package]]
 name = "wormhole-svm-shim"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole.git?rev=33dd6a56541c2d15d3e20faa1330ba542a5fa727#33dd6a56541c2d15d3e20faa1330ba542a5fa727"
 dependencies = [
  "solana-program",
  "wormhole-svm-definitions",
@@ -7173,11 +7171,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "wormhole-svm-definitions"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "wormhole-svm-shim"
-version = "0.1.0"

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -52,7 +52,7 @@ bytemuck = "1.13.0"
 wormhole-svm-shim = { git = "https://github.com/wormhole-foundation/wormhole.git", rev = "33dd6a56541c2d15d3e20faa1330ba542a5fa727" }
 wormhole-svm-definitions = { git = "https://github.com/wormhole-foundation/wormhole.git", rev = "33dd6a56541c2d15d3e20faa1330ba542a5fa727", features = ["borsh"] }
 
-[patch."https://github.com/wormholelabs-xyz/wormhole.git"]
+[patch."https://github.com/wormhole-foundation/wormhole.git"]
 wormhole-svm-shim = { path = "lib/wormhole/svm/wormhole-core-shims/crates/shim" }
 wormhole-svm-definitions = { path = "lib/wormhole/svm/wormhole-core-shims/crates/definitions" }
 

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_execute_order.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_execute_order.rs
@@ -8,7 +8,7 @@ use common::wormhole_cctp_solana::cctp::{
     MESSAGE_TRANSMITTER_PROGRAM_ID, TOKEN_MESSENGER_MINTER_PROGRAM_ID,
 };
 use matching_engine::accounts::CctpDepositForBurn;
-use matching_engine::fallback::execute_order::{ExecuteOrderCctpShim, ExecuteOrderShimAccounts};
+use matching_engine::fallback::execute_order::{ExecuteOrderCctpShim, ExecuteOrderV2Accounts};
 use solana_program_test::ProgramTestContext;
 use solana_sdk::{pubkey::Pubkey, signer::Signer, sysvar::SysvarId};
 use utils::constants::*;
@@ -261,8 +261,8 @@ fn create_order_executed_state(
 fn create_execute_order_shim_accounts<'ix>(
     execute_order_fallback_accounts: &'ix ExecuteOrderShimfulAccounts,
     clock_id: &'ix Pubkey,
-) -> ExecuteOrderShimAccounts<'ix> {
-    ExecuteOrderShimAccounts {
+) -> ExecuteOrderV2Accounts<'ix> {
+    ExecuteOrderV2Accounts {
         payer: &execute_order_fallback_accounts.signer, // 0
         new_cctp_message: &execute_order_fallback_accounts.cctp_message, // 1
         custodian: &execute_order_fallback_accounts.custodian, // 2
@@ -297,9 +297,6 @@ fn create_execute_order_shim_accounts<'ix>(
         core_bridge_config: &CORE_BRIDGE_CONFIG,                                            // 26
         core_bridge_fee_collector: &CORE_BRIDGE_FEE_COLLECTOR,                              // 27
         post_message_shim_event_authority: &POST_MESSAGE_SHIM_EVENT_AUTHORITY,              // 28
-        system_program: &solana_program::system_program::ID,                                // 29
-        token_program: &spl_token::ID,                                                      // 30
-        clock: clock_id,                                                                    // 31
     }
 }
 

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_execute_order.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_execute_order.rs
@@ -263,22 +263,22 @@ fn create_execute_order_shim_accounts<'ix>(
     clock_id: &'ix Pubkey,
 ) -> ExecuteOrderShimAccounts<'ix> {
     ExecuteOrderShimAccounts {
-        signer: &execute_order_fallback_accounts.signer, // 0
-        cctp_message: &execute_order_fallback_accounts.cctp_message, // 1
+        payer: &execute_order_fallback_accounts.signer, // 0
+        new_cctp_message: &execute_order_fallback_accounts.cctp_message, // 1
         custodian: &execute_order_fallback_accounts.custodian, // 2
         fast_market_order: &execute_order_fallback_accounts.fast_market_order_address, // 3
         active_auction: &execute_order_fallback_accounts.active_auction, // 4
-        active_auction_custody_token: &execute_order_fallback_accounts.active_auction_custody_token, // 5
-        active_auction_config: &execute_order_fallback_accounts.active_auction_config, // 6
-        active_auction_best_offer_token: &execute_order_fallback_accounts
+        auction_custody: &execute_order_fallback_accounts.active_auction_custody_token, // 5
+        auction_config: &execute_order_fallback_accounts.active_auction_config, // 6
+        auction_best_offer_token: &execute_order_fallback_accounts
             .active_auction_best_offer_token, // 7
         executor_token: &execute_order_fallback_accounts.executor_token,               // 8
-        initial_offer_token: &execute_order_fallback_accounts.initial_offer_token,     // 9
-        initial_participant: &execute_order_fallback_accounts.initial_participant,     // 10
-        to_router_endpoint: &execute_order_fallback_accounts.to_router_endpoint,       // 11
+        auction_initial_offer_token: &execute_order_fallback_accounts.initial_offer_token,     // 9
+        auction_initial_participant: &execute_order_fallback_accounts.initial_participant,     // 10
+        to_endpoint: &execute_order_fallback_accounts.to_router_endpoint,       // 11
         post_message_shim_program: &POST_MESSAGE_SHIM_PROGRAM_ID,                      // 12
         core_bridge_emitter_sequence: &execute_order_fallback_accounts.post_message_sequence, // 13
-        post_shim_message: &execute_order_fallback_accounts.post_message_message,      // 14
+        shim_message: &execute_order_fallback_accounts.post_message_message,      // 14
         cctp_deposit_for_burn_mint: &USDC_MINT,                                        // 15
         cctp_deposit_for_burn_token_messenger_minter_sender_authority:
             &execute_order_fallback_accounts.token_messenger_minter_sender_authority, // 16

--- a/solana/modules/matching-engine-testing/tests/testing_engine/config.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/config.rs
@@ -178,8 +178,25 @@ impl InstructionConfig for PrepareOrderResponseInstructionConfig {
 }
 
 #[derive(Clone)]
+pub struct OverwriteAccounts(pub Vec<OverwriteAccountField>);
+
+impl Deref for OverwriteAccounts {
+    type Target = Vec<OverwriteAccountField>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone)]
+pub enum OverwriteAccountField {
+    CctpTokenMessengerMinter(Pubkey),
+    // Add other fields here if needed
+}
+
+#[derive(Clone)]
 pub struct ExecuteOrderInstructionConfig {
-    pub fast_market_order_address: OverwriteCurrentState<Pubkey>,
+    pub overwrite_accounts: OverwriteCurrentState<OverwriteAccounts>,
     pub actor_enum: TestingActorEnum,
     pub token_enum: SplTokenEnum,
     pub vaa_index: usize,
@@ -194,7 +211,7 @@ impl Default for ExecuteOrderInstructionConfig {
         Self {
             fast_forward_slots: 3,
             actor_enum: TestingActorEnum::default(),
-            fast_market_order_address: None,
+            overwrite_accounts: None,
             token_enum: SplTokenEnum::default(),
             vaa_index: 0,
             payer_signer: None,

--- a/solana/programs/matching-engine/src/fallback/processor/execute_order.rs
+++ b/solana/programs/matching-engine/src/fallback/processor/execute_order.rs
@@ -18,9 +18,8 @@ use super::burn_and_post::{burn_and_post, PostMessageAccounts};
 
 const NUM_ACCOUNTS: usize = 32;
 
-// TODO: Rename to "ExecuteOrderCctpV2Accounts".
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
-pub struct ExecuteOrderShimAccounts<'ix> {
+pub struct ExecuteOrderV2Accounts<'ix> {
     /// The signer account.
     pub payer: &'ix Pubkey, // 0
     /// The cctp message account. Seeds must be \["cctp-msg", auction_address.as_ref()\].
@@ -78,26 +77,18 @@ pub struct ExecuteOrderShimAccounts<'ix> {
     pub core_bridge_fee_collector: &'ix Pubkey, // 27
     /// The event authority account of the post message shim program
     pub post_message_shim_event_authority: &'ix Pubkey, // 28
-    /// The program id of the system program
-    // TODO: Remove.
-    pub system_program: &'ix Pubkey, // 29
-    /// The program id of the token program
-    // TODO: Remove.
-    pub token_program: &'ix Pubkey, // 30
-    /// The clock account
-    // TODO: Remove.
-    pub clock: &'ix Pubkey, // 31
 }
+    
 
 // TODO: Rename to "ExecuteOrderCctpV2".
 pub struct ExecuteOrderCctpShim<'ix> {
     pub program_id: &'ix Pubkey,
-    pub accounts: ExecuteOrderShimAccounts<'ix>,
+    pub accounts: ExecuteOrderV2Accounts<'ix>,
 }
 
 impl ExecuteOrderCctpShim<'_> {
     pub fn instruction(&self) -> Instruction {
-        let ExecuteOrderShimAccounts {
+        let ExecuteOrderV2Accounts {
             payer,
             new_cctp_message,
             custodian,
@@ -130,9 +121,6 @@ impl ExecuteOrderCctpShim<'_> {
             core_bridge_config,
             core_bridge_fee_collector,
             post_message_shim_event_authority,
-            system_program: _,
-            token_program: _,
-            clock: _,
         } = self.accounts;
 
         let accounts = vec![
@@ -470,7 +458,7 @@ mod test {
     fn test_instruction() {
         ExecuteOrderCctpShim {
             program_id: &Default::default(),
-            accounts: ExecuteOrderShimAccounts {
+            accounts: ExecuteOrderV2Accounts {
                 payer: &Default::default(),
                 new_cctp_message: &Default::default(),
                 custodian: &Default::default(),
@@ -500,9 +488,6 @@ mod test {
                 core_bridge_config: &Default::default(),
                 core_bridge_fee_collector: &Default::default(),
                 post_message_shim_event_authority: &Default::default(),
-                system_program: &Default::default(),
-                token_program: &Default::default(),
-                clock: &Default::default(),
             },
         }
         .instruction();

--- a/solana/programs/matching-engine/src/fallback/processor/execute_order.rs
+++ b/solana/programs/matching-engine/src/fallback/processor/execute_order.rs
@@ -22,43 +22,34 @@ const NUM_ACCOUNTS: usize = 32;
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ExecuteOrderShimAccounts<'ix> {
     /// The signer account.
-    // TODO: Rename to "payer".
-    pub signer: &'ix Pubkey, // 0
+    pub payer: &'ix Pubkey, // 0
     /// The cctp message account. Seeds must be \["cctp-msg", auction_address.as_ref()\].
-    // TODO: Rename to "new_cctp_message".
-    pub cctp_message: &'ix Pubkey, // 1
+    pub new_cctp_message: &'ix Pubkey, // 1
     pub custodian: &'ix Pubkey, // 2
     /// Seeds must be \["fast_market_order", auction_address.as_ref()\].
     pub fast_market_order: &'ix Pubkey, // 3
     /// The auction account created from the place initial offer instruction.
     pub active_auction: &'ix Pubkey, // 4
     /// The associated token address of the auction's custody token.
-    // TODO: Rename to "auction_custody".
-    pub active_auction_custody_token: &'ix Pubkey, // 5
+    pub auction_custody: &'ix Pubkey, // 5
     /// The auction config account created from the place initial offer instruction.
-    // TODO: Rename to "auction_config".
-    pub active_auction_config: &'ix Pubkey, // 6
+    pub auction_config: &'ix Pubkey, // 6
     /// The token account of the auction's best offer
-    // TODO: Rename to "auction_best_offer_token".
-    pub active_auction_best_offer_token: &'ix Pubkey, // 7
+    pub auction_best_offer_token: &'ix Pubkey, // 7
     /// The token account of the executor
     pub executor_token: &'ix Pubkey, // 8
     /// The token account of the auction's initial offer
-    // TODO: Rename to "auction_initial_offer_token".
-    pub initial_offer_token: &'ix Pubkey, // 9
+    pub auction_initial_offer_token: &'ix Pubkey, // 9
     /// The account that signed the creation of the auction when placing the initial offer.
-    // TODO: Rename to "auction_initial_participant".
-    pub initial_participant: &'ix Pubkey, // 10
+    pub auction_initial_participant: &'ix Pubkey, // 10
     /// The router endpoint account of the auction's target chain
-    // TODO: Rename to "to_endpoint".
-    pub to_router_endpoint: &'ix Pubkey, // 11
+    pub to_endpoint: &'ix Pubkey, // 11
     /// The program id of the post message shim program
     pub post_message_shim_program: &'ix Pubkey, // 12
     /// The emitter sequence of the core bridge program (can be derived)
     pub core_bridge_emitter_sequence: &'ix Pubkey, // 13
     /// The message account of the post message shim program (can be derived)
-    // TODO: Rename to "shim_message".
-    pub post_shim_message: &'ix Pubkey, // 14
+    pub shim_message: &'ix Pubkey, // 14
     pub cctp_deposit_for_burn_token_messenger_minter_program: &'ix Pubkey, // 15
     /// The mint account of the CCTP token to be burned
     pub cctp_deposit_for_burn_mint: &'ix Pubkey, // 16
@@ -107,21 +98,21 @@ pub struct ExecuteOrderCctpShim<'ix> {
 impl ExecuteOrderCctpShim<'_> {
     pub fn instruction(&self) -> Instruction {
         let ExecuteOrderShimAccounts {
-            signer: payer,
-            cctp_message: new_cctp_message,
+            payer,
+            new_cctp_message,
             custodian,
             fast_market_order,
             active_auction,
-            active_auction_custody_token: auction_custody,
-            active_auction_config: auction_config,
-            active_auction_best_offer_token: auction_best_offer_token,
+            auction_custody,
+            auction_config,
+            auction_best_offer_token,
             executor_token,
-            initial_offer_token: auction_initial_offer_token,
-            initial_participant: auction_initial_participant,
-            to_router_endpoint: to_endpoint,
+            auction_initial_offer_token,
+            auction_initial_participant,
+            to_endpoint,
             post_message_shim_program,
             core_bridge_emitter_sequence,
-            post_shim_message: shim_message,
+            shim_message,
             cctp_deposit_for_burn_mint: cctp_mint,
             cctp_deposit_for_burn_token_messenger_minter_sender_authority:
                 cctp_token_messenger_minter_sender_authority,
@@ -480,21 +471,21 @@ mod test {
         ExecuteOrderCctpShim {
             program_id: &Default::default(),
             accounts: ExecuteOrderShimAccounts {
-                signer: &Default::default(),
-                cctp_message: &Default::default(),
+                payer: &Default::default(),
+                new_cctp_message: &Default::default(),
                 custodian: &Default::default(),
                 fast_market_order: &Default::default(),
                 active_auction: &Default::default(),
-                active_auction_custody_token: &Default::default(),
-                active_auction_config: &Default::default(),
-                active_auction_best_offer_token: &Default::default(),
+                auction_custody: &Default::default(),
+                auction_config: &Default::default(),
+                auction_best_offer_token: &Default::default(),
                 executor_token: &Default::default(),
-                initial_offer_token: &Default::default(),
-                initial_participant: &Default::default(),
-                to_router_endpoint: &Default::default(),
+                auction_initial_offer_token: &Default::default(),
+                auction_initial_participant: &Default::default(),
+                to_endpoint: &Default::default(),
                 post_message_shim_program: &Default::default(),
                 core_bridge_emitter_sequence: &Default::default(),
-                post_shim_message: &Default::default(),
+                shim_message: &Default::default(),
                 cctp_deposit_for_burn_mint: &Default::default(),
                 cctp_deposit_for_burn_token_messenger_minter_sender_authority: &Default::default(),
                 cctp_deposit_for_burn_message_transmitter_config: &Default::default(),


### PR DESCRIPTION
## Description

This pr addresses various todos in the execute order shim

## Changes

- [x] Changes the name of accounts and deletes some unnecessary accounts in the builder struct
- [x] Changes the name of execute order shim instruction to `ExecuteOrderV2`
- [x] Adds a test to see if a check needs to be done against cctp messenger minter program
- [x] Adds a negative test to see if passing in an incorrect cctp message leads to an error
- [x] Added check on cctp message because no check felt unsafe, despite negative test passing (the error seemed dubious and the cost of checking was small)
