### PR TITLE
Shim/integration program todos/init fast market order

### DIFF
--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -6971,7 +6971,6 @@ dependencies = [
 [[package]]
 name = "wormhole-svm-definitions"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole.git?rev=33dd6a56541c2d15d3e20faa1330ba542a5fa727#33dd6a56541c2d15d3e20faa1330ba542a5fa727"
 dependencies = [
  "borsh 1.5.0",
  "cfg-if",
@@ -6982,7 +6981,6 @@ dependencies = [
 [[package]]
 name = "wormhole-svm-shim"
 version = "0.1.0"
-source = "git+https://github.com/wormhole-foundation/wormhole.git?rev=33dd6a56541c2d15d3e20faa1330ba542a5fa727#33dd6a56541c2d15d3e20faa1330ba542a5fa727"
 dependencies = [
  "solana-program",
  "wormhole-svm-definitions",
@@ -7173,11 +7171,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "wormhole-svm-definitions"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "wormhole-svm-shim"
-version = "0.1.0"

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -52,7 +52,7 @@ bytemuck = "1.13.0"
 wormhole-svm-shim = { git = "https://github.com/wormhole-foundation/wormhole.git", rev = "33dd6a56541c2d15d3e20faa1330ba542a5fa727" }
 wormhole-svm-definitions = { git = "https://github.com/wormhole-foundation/wormhole.git", rev = "33dd6a56541c2d15d3e20faa1330ba542a5fa727", features = ["borsh"] }
 
-[patch."https://github.com/wormholelabs-xyz/wormhole.git"]
+[patch."https://github.com/wormhole-foundation/wormhole.git"]
 wormhole-svm-shim = { path = "lib/wormhole/svm/wormhole-core-shims/crates/shim" }
 wormhole-svm-definitions = { path = "lib/wormhole/svm/wormhole-core-shims/crates/definitions" }
 

--- a/solana/Makefile
+++ b/solana/Makefile
@@ -75,7 +75,7 @@ test-sbf:
 	cargo build-sbf --features mainnet
 ### Unfortunately we cannot saturate all CPUs to perform tests due to nondeterministic `RpcError`
 ### reverts. We constrain the number of threads when we run these tests.
-	cd modules/matching-engine-testing && cargo test-sbf --features mainnet -- --test-threads 1
+	cd modules/matching-engine-testing && cargo test-sbf --features mainnet -- --test-threads 5
 
 .PHONY: anchor-test
 anchor-test: anchor-test-setup

--- a/solana/modules/matching-engine-testing/tests/shimful/fast_market_order_shim.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/fast_market_order_shim.rs
@@ -61,7 +61,7 @@ pub async fn initialize_fast_market_order_shimful(
     let payer_signer = config
         .payer_signer
         .clone()
-        .unwrap_or_else(|| testing_context.testing_actors.payer_signer.clone());
+        .unwrap_or_else(|| testing_context.testing_actors.solvers[0].keypair().clone());
     let guardian_signature_info = create_guardian_signatures(
         testing_context,
         test_context,
@@ -77,7 +77,7 @@ pub async fn initialize_fast_market_order_shimful(
         &[
             FastMarketOrderState::SEED_PREFIX,
             &fast_market_order.digest().as_ref(),
-            &fast_market_order.close_account_refund_recipient.as_ref(),
+            &payer_signer.pubkey().as_ref(),
         ],
         program_id,
     );
@@ -157,7 +157,7 @@ pub fn initialize_fast_market_order_shimful_instruction(
         &[
             FastMarketOrderState::SEED_PREFIX,
             &fast_market_order.digest().as_ref(),
-            &fast_market_order.close_account_refund_recipient.as_ref(),
+            &payer_signer.pubkey().as_ref(),
         ],
         program_id,
     )

--- a/solana/modules/matching-engine-testing/tests/shimful/fast_market_order_shim.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/fast_market_order_shim.rs
@@ -162,13 +162,12 @@ pub fn initialize_fast_market_order_shimful_instruction(
     .0;
 
     let create_fast_market_order_accounts = InitializeFastMarketOrderFallbackAccounts {
-        signer: &payer_signer.pubkey(),
-        fast_market_order_account: &fast_market_order_account,
+        payer: &payer_signer.pubkey(),
+        new_fast_market_order: &fast_market_order_account,
         guardian_set: &guardian_signature_info.guardian_set_pubkey,
-        guardian_set_signatures: &guardian_signature_info.guardian_signatures_pubkey,
+        shim_guardian_signatures: &guardian_signature_info.guardian_signatures_pubkey,
         from_endpoint,
         verify_vaa_shim_program: &WORMHOLE_VERIFY_VAA_SHIM_PID,
-        system_program: &solana_program::system_program::ID,
     };
 
     InitializeFastMarketOrderFallback {

--- a/solana/modules/matching-engine-testing/tests/shimful/shims_prepare_order_response.rs
+++ b/solana/modules/matching-engine-testing/tests/shimful/shims_prepare_order_response.rs
@@ -384,7 +384,7 @@ impl PrepareOrderResponseShimAccountsHelper {
         let fast_market_order_digest = data.fast_market_order.digest();
         let prepared_order_response_seeds = [
             PreparedOrderResponse::SEED_PREFIX,
-            &fast_market_order_digest,
+            &fast_market_order_digest.as_ref(),
         ];
 
         let (prepared_order_response_pda, _prepared_order_response_bump) =

--- a/solana/modules/matching-engine-testing/tests/test_scenarios/make_offer.rs
+++ b/solana/modules/matching-engine-testing/tests/test_scenarios/make_offer.rs
@@ -83,7 +83,8 @@ pub async fn test_place_initial_offer_shimful() {
             .fast_market_order()
             .unwrap()
             .fast_market_order
-            .digest(),
+            .digest()
+            .as_ref(),
         final_state
             .base()
             .vaas

--- a/solana/modules/matching-engine-testing/tests/testing_engine/config.rs
+++ b/solana/modules/matching-engine-testing/tests/testing_engine/config.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use crate::{
-    shimful::fast_market_order_shim::create_fast_market_order_state_from_vaa_data,
+    shimful::fast_market_order_shim::create_fast_market_order_params_from_vaa_data,
     shimless::initialize::AuctionParametersConfig,
     utils::{
         auction::{ActiveAuctionState, AuctionAccounts},
@@ -657,14 +657,15 @@ impl CombinedInstructionConfig {
     ) -> Self {
         let test_vaa_pair = current_state.get_test_vaa_pair(0);
         let fast_transfer_vaa = test_vaa_pair.fast_transfer_vaa.clone();
-        let fast_market_order = create_fast_market_order_state_from_vaa_data(
+        let fast_market_order_params = create_fast_market_order_params_from_vaa_data(
             &fast_transfer_vaa.vaa_data,
             testing_actors.solvers[0].pubkey(),
         );
+        let fast_market_order = FastMarketOrderState::new(&fast_market_order_params);
         let (fast_market_order_address, _fast_market_order_bump) = Pubkey::find_program_address(
             &[
                 FastMarketOrderState::SEED_PREFIX,
-                &fast_market_order.digest(),
+                &fast_market_order.digest().as_ref(),
                 &fast_market_order.close_account_refund_recipient.as_ref(),
             ],
             program_id,

--- a/solana/programs/matching-engine/src/error.rs
+++ b/solana/programs/matching-engine/src/error.rs
@@ -92,7 +92,7 @@ pub enum MatchingEngineError {
 
     InvalidVerifyVaaShimProgram = 0x600,
 
-    // Fallback matching engine errors
+    // V2 matching engine errors
     AccountAlreadyInitialized = 0x700,
     AccountNotWritable = 0x702,
     BorshDeserializationError = 0x704,

--- a/solana/programs/matching-engine/src/fallback/processor/execute_order.rs
+++ b/solana/programs/matching-engine/src/fallback/processor/execute_order.rs
@@ -213,7 +213,7 @@ pub(super) fn process(accounts: &[AccountInfo]) -> Result<()> {
     let active_auction_inner_info = active_auction.info.as_ref().unwrap();
 
     require!(
-        active_auction.vaa_hash == fast_market_order.digest(),
+        active_auction.vaa_hash == fast_market_order.digest().as_ref(),
         MatchingEngineError::VaaMismatch
     );
 

--- a/solana/programs/matching-engine/src/fallback/processor/initialize_fast_market_order.rs
+++ b/solana/programs/matching-engine/src/fallback/processor/initialize_fast_market_order.rs
@@ -10,8 +10,7 @@ pub struct InitializeFastMarketOrderAccounts<'ix> {
     /// Lamports from this signer will be used to create the new fast market
     /// order account. This account will be the only authority allowed to
     /// close this account.
-    // TODO: Rename to "payer".
-    pub signer: &'ix Pubkey, // 0
+    pub payer: &'ix Pubkey, // 0
 
     /// The from router endpoint account for the hash of the fast market order
     pub from_endpoint: &'ix Pubkey,
@@ -21,14 +20,10 @@ pub struct InitializeFastMarketOrderAccounts<'ix> {
     pub verify_vaa_shim_program: &'ix Pubkey, // 1
     pub guardian_set: &'ix Pubkey, // 2
     /// The guardian set signatures of fast market order VAA.
-    // TODO: Rename to "shim_guardian_signatures".
-    pub guardian_set_signatures: &'ix Pubkey, // 3
+    pub shim_guardian_signatures: &'ix Pubkey, // 3
     /// The fast market order account pubkey (that is created by the
     /// instruction).
-    // TODO: Rename to "new_fast_market_order".
-    pub fast_market_order_account: &'ix Pubkey, // 4
-    // TODO: Remove.
-    pub system_program: &'ix Pubkey, // 5
+    pub new_fast_market_order: &'ix Pubkey, // 4
 }
 
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
@@ -71,14 +66,13 @@ pub struct InitializeFastMarketOrder<'ix> {
 impl InitializeFastMarketOrder<'_> {
     pub fn instruction(&self) -> Instruction {
         let InitializeFastMarketOrderAccounts {
-            signer: payer,
-            fast_market_order_account: new_fast_market_order,
+            payer,
+            new_fast_market_order,
             from_endpoint,
 
             guardian_set: wormhole_guardian_set,
-            guardian_set_signatures: shim_guardian_signatures,
+            shim_guardian_signatures,
             verify_vaa_shim_program,
-            system_program: _,
         } = self.accounts;
 
         let accounts = vec![
@@ -195,13 +189,12 @@ mod test {
         InitializeFastMarketOrder {
             program_id: &Default::default(),
             accounts: InitializeFastMarketOrderAccounts {
-                signer: &Default::default(),
-                fast_market_order_account: &Default::default(),
+                payer: &Default::default(),
+                new_fast_market_order: &Default::default(),
                 from_endpoint: &Default::default(),
                 verify_vaa_shim_program: &Default::default(),
                 guardian_set: &Default::default(),
-                guardian_set_signatures: &Default::default(),
-                system_program: &Default::default(),
+                shim_guardian_signatures: &Default::default(),
             },
             data: InitializeFastMarketOrderData::new(
                 FastMarketOrder::new(FastMarketOrderParams {

--- a/solana/programs/matching-engine/src/fallback/processor/initialize_fast_market_order.rs
+++ b/solana/programs/matching-engine/src/fallback/processor/initialize_fast_market_order.rs
@@ -115,6 +115,12 @@ pub(super) fn process(
     // fast market order account.
     let payer_info = &accounts[0];
 
+    require_keys_eq!(
+        *payer_info.key,
+        fast_market_order.close_account_refund_recipient,
+        MatchingEngineError::MismatchingCloseAccountRefundRecipient
+    );
+
     // These accounts will be used by the Verify VAA shim program.
     let from_endpoint = super::helpers::try_live_endpoint_account(&accounts[1], "from_endpoint")
         .map_err(|e: Error| e.with_account_name("from_endpoint"))?;
@@ -143,7 +149,7 @@ pub(super) fn process(
         &[
             FastMarketOrder::SEED_PREFIX,
             &fast_market_order_vaa_digest.as_ref(),
-            fast_market_order.close_account_refund_recipient.as_ref(),
+            payer_info.key.as_ref(),
         ],
         &ID,
     );
@@ -162,8 +168,7 @@ pub(super) fn process(
         &[&[
             FastMarketOrder::SEED_PREFIX,
             &fast_market_order_vaa_digest.as_ref(),
-            // TODO: Replace with payer_info.key.
-            fast_market_order.close_account_refund_recipient.as_ref(),
+            payer_info.key.as_ref(),
             &[fast_market_order_bump],
         ]],
     )?;

--- a/solana/programs/matching-engine/src/fallback/processor/initialize_fast_market_order.rs
+++ b/solana/programs/matching-engine/src/fallback/processor/initialize_fast_market_order.rs
@@ -1,8 +1,12 @@
 use anchor_lang::{prelude::*, Discriminator};
 use bytemuck::{Pod, Zeroable};
-use solana_program::{instruction::Instruction, keccak};
+use solana_program::instruction::Instruction;
 
-use crate::{error::MatchingEngineError, state::FastMarketOrder, ID};
+use crate::{
+    error::MatchingEngineError,
+    state::{FastMarketOrder, FastMarketOrderParams},
+    ID,
+};
 
 const NUM_ACCOUNTS: usize = 7;
 
@@ -11,19 +15,18 @@ pub struct InitializeFastMarketOrderAccounts<'ix> {
     /// order account. This account will be the only authority allowed to
     /// close this account.
     pub payer: &'ix Pubkey, // 0
-
     /// The from router endpoint account for the hash of the fast market order
-    pub from_endpoint: &'ix Pubkey,
+    pub from_endpoint: &'ix Pubkey, // 1
+    /// The verify VAA shim program account
+    pub verify_vaa_shim_program: &'ix Pubkey, // 2
     /// Wormhole guardian set account used to check recovered pubkeys using
     /// [Self::guardian_set_signatures].
-    // TODO: Rename to "wormhole_guardian_set"
-    pub verify_vaa_shim_program: &'ix Pubkey, // 1
-    pub guardian_set: &'ix Pubkey, // 2
+    pub wormhole_guardian_set: &'ix Pubkey, // 3
     /// The guardian set signatures of fast market order VAA.
-    pub shim_guardian_signatures: &'ix Pubkey, // 3
+    pub shim_guardian_signatures: &'ix Pubkey, // 4
     /// The fast market order account pubkey (that is created by the
     /// instruction).
-    pub new_fast_market_order: &'ix Pubkey, // 4
+    pub new_fast_market_order: &'ix Pubkey, // 5
 }
 
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
@@ -39,10 +42,9 @@ pub struct InitializeFastMarketOrderData {
 
 impl InitializeFastMarketOrderData {
     // Adds the padding to the InitializeFastMarketOrderData
-    // TODO: change FastMarketOrder to FastMarketOrderParams.
-    pub fn new(fast_market_order: FastMarketOrder, guardian_set_bump: u8) -> Self {
+    pub fn new(fast_market_order_params: &FastMarketOrderParams, guardian_set_bump: u8) -> Self {
         Self {
-            fast_market_order,
+            fast_market_order: FastMarketOrder::new(fast_market_order_params),
             guardian_set_bump,
             _padding: Default::default(),
         }
@@ -70,7 +72,7 @@ impl InitializeFastMarketOrder<'_> {
             new_fast_market_order,
             from_endpoint,
 
-            guardian_set: wormhole_guardian_set,
+            wormhole_guardian_set,
             shim_guardian_signatures,
             verify_vaa_shim_program,
         } = self.accounts;
@@ -129,7 +131,7 @@ pub(super) fn process(
         3, // wormhole_guardian_set_index
         4, // shim_guardian_signatures_index
         data.guardian_set_bump,
-        keccak::Hash(fast_market_order_vaa_digest),
+        fast_market_order_vaa_digest,
         accounts,
     )?;
 
@@ -140,7 +142,7 @@ pub(super) fn process(
     let (expected_fast_market_order_key, fast_market_order_bump) = Pubkey::find_program_address(
         &[
             FastMarketOrder::SEED_PREFIX,
-            &fast_market_order_vaa_digest,
+            &fast_market_order_vaa_digest.as_ref(),
             fast_market_order.close_account_refund_recipient.as_ref(),
         ],
         &ID,
@@ -159,7 +161,7 @@ pub(super) fn process(
         &ID,
         &[&[
             FastMarketOrder::SEED_PREFIX,
-            &fast_market_order_vaa_digest,
+            &fast_market_order_vaa_digest.as_ref(),
             // TODO: Replace with payer_info.key.
             fast_market_order.close_account_refund_recipient.as_ref(),
             &[fast_market_order_bump],
@@ -193,11 +195,11 @@ mod test {
                 new_fast_market_order: &Default::default(),
                 from_endpoint: &Default::default(),
                 verify_vaa_shim_program: &Default::default(),
-                guardian_set: &Default::default(),
+                wormhole_guardian_set: &Default::default(),
                 shim_guardian_signatures: &Default::default(),
             },
             data: InitializeFastMarketOrderData::new(
-                FastMarketOrder::new(FastMarketOrderParams {
+                &FastMarketOrderParams {
                     amount_in: Default::default(),
                     min_amount_out: Default::default(),
                     deadline: Default::default(),
@@ -215,7 +217,7 @@ mod test {
                     vaa_emitter_chain: Default::default(),
                     vaa_consistency_level: Default::default(),
                     vaa_emitter_address: Default::default(),
-                }),
+                },
                 Default::default(),
             ),
         }

--- a/solana/programs/matching-engine/src/fallback/processor/place_initial_offer.rs
+++ b/solana/programs/matching-engine/src/fallback/processor/place_initial_offer.rs
@@ -344,7 +344,7 @@ mod tests {
 
     #[test]
     fn test_bytemuck() {
-        let test_fast_market_order = FastMarketOrder::new(FastMarketOrderParams {
+        let test_fast_market_order = FastMarketOrder::new(&FastMarketOrderParams {
             amount_in: 1000000000000000000,
             min_amount_out: 1000000000000000000,
             deadline: 1000000000,

--- a/solana/programs/matching-engine/src/fallback/processor/prepare_order_response.rs
+++ b/solana/programs/matching-engine/src/fallback/processor/prepare_order_response.rs
@@ -280,7 +280,7 @@ pub(super) fn process(
         Pubkey::find_program_address(
             &[
                 PreparedOrderResponse::SEED_PREFIX,
-                &fast_market_order_digest,
+                &fast_market_order_digest.as_ref(),
             ],
             &ID,
         );
@@ -294,7 +294,7 @@ pub(super) fn process(
         &ID,
         &[&[
             PreparedOrderResponse::SEED_PREFIX,
-            &fast_market_order_digest,
+            &fast_market_order_digest.as_ref(),
             &[prepared_order_response_bump],
         ]],
     )?;
@@ -411,7 +411,7 @@ pub(super) fn process(
 
     PreparedOrderResponse {
         seeds: PreparedOrderResponseSeeds {
-            fast_vaa_hash: fast_market_order_digest,
+            fast_vaa_hash: <[u8; 32]>::try_from(fast_market_order_digest.as_ref()).unwrap(),
             bump: prepared_order_response_bump,
         },
         info: PreparedOrderResponseInfo {

--- a/solana/programs/matching-engine/src/state/fast_market_order.rs
+++ b/solana/programs/matching-engine/src/state/fast_market_order.rs
@@ -64,7 +64,7 @@ pub struct FastMarketOrderParams {
     pub max_fee: u64,
     pub init_auction_fee: u64,
     pub redeemer_message: [u8; 512],
-    pub close_account_refund_recipient: Pubkey,
+    pub close_account_refund_recipient: Pubkey, // Same as the payer
     pub vaa_sequence: u64,
     pub vaa_timestamp: u32,
     pub vaa_emitter_chain: u16,

--- a/solana/programs/matching-engine/src/state/fast_market_order.rs
+++ b/solana/programs/matching-engine/src/state/fast_market_order.rs
@@ -75,7 +75,7 @@ pub struct FastMarketOrderParams {
 impl FastMarketOrder {
     pub const SEED_PREFIX: &'static [u8] = b"fast_market_order";
 
-    pub fn new(params: FastMarketOrderParams) -> Self {
+    pub fn new(params: &FastMarketOrderParams) -> Self {
         Self {
             amount_in: params.amount_in,
             min_amount_out: params.min_amount_out,
@@ -123,7 +123,7 @@ impl FastMarketOrder {
     /// A double hash of the serialised fast market order. Used for seeds and
     /// verification.
     // TODO: Change return type to keccak::Hash
-    pub fn digest(&self) -> [u8; 32] {
+    pub fn digest(&self) -> keccak::Hash {
         wormhole_svm_definitions::compute_keccak_digest(
             keccak::hashv(&[
                 &self.vaa_timestamp.to_be_bytes(),
@@ -137,6 +137,5 @@ impl FastMarketOrder {
             ]),
             None,
         )
-        .0
     }
 }


### PR DESCRIPTION
## Description

Addressing todos in the instruction for the initialize_fast_market_order 

## Changes
- [x] Changed the variable names in the accounts struct
- [x] Changed instruction data to take `FastMarketOrderParams` struct instead of the `FastMarketOrder` account struct
- [ ] Force the payer to be the `close_account_refund_recipient`

## Currently failing tests

There are currently a few failing tests that use custom actors to initialize fast market orders and close them. I suspect this is mainly logic on the testing side that hasn't accommodated the new changes to the program, but needs further investigation and work. Until these tests are fixed, do NOT change into a PR from Draft